### PR TITLE
Promover dev → main: PM-111 + PM-96

### DIFF
--- a/src/app/(app)/dashboard/admin/page.tsx
+++ b/src/app/(app)/dashboard/admin/page.tsx
@@ -5,6 +5,7 @@ import Carrousel from "@/components/ui/card/projectCarrousel"
 import { Card, CardContent } from "@/components/ui/card/card"
 import PerformanceChart from "@/components/ui/graphs/performaceChart"
 import Filters from "@/components/ui/filters/filters"
+import AdminProfileChangeRequests from "@/components/profile/AdminProfileChangeRequests"
 
 type FiltersState = {
   sprint?: string
@@ -74,6 +75,12 @@ export default function DashboardPage() {
           </div>
 
         </div>
+
+        <Card className="w-full">
+          <CardContent className="p-4 sm:p-6">
+            <AdminProfileChangeRequests />
+          </CardContent>
+        </Card>
       </div>
     </div>
   )

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -18,6 +18,13 @@ import {
 import { useLanguage } from "@/components/i18n/LanguageProvider";
 import { Task } from "@/types/task";
 import ThemeToggle from "@/components/ui/ThemeToggle";
+import RequestModificationModal from "@/components/profile/RequestModificationModal";
+import {
+  ProfileChangeRequest,
+  ProfileChangeStatus,
+  cancelProfileChangeRequest,
+  getMyProfileChangeRequests,
+} from "@/services/profileChangeRequestService";
 
 function splitValues(value: string | null | undefined): string[] {
   if (!value) return [];
@@ -85,6 +92,58 @@ function getTaskProgressColor(status: Task["status"]): string {
   }
 }
 
+const PROFILE_REQUEST_FIELD_LABELS: Record<string, string> = {
+  name: "Nombre",
+  lastname: "Apellido",
+  email: "Email",
+  skill: "Skill",
+  area: "Área",
+}
+
+function getRequestStatusStyles(status: ProfileChangeStatus): string {
+  switch (status) {
+    case "approved":
+      return "bg-emerald-100 text-emerald-700"
+    case "rejected":
+      return "bg-red-100 text-red-700"
+    case "cancelled":
+      return "bg-slate-100 text-slate-600"
+    default:
+      return "bg-amber-100 text-amber-700"
+  }
+}
+
+function getRequestStatusLabel(status: ProfileChangeStatus): string {
+  switch (status) {
+    case "approved":
+      return "Aprobada"
+    case "rejected":
+      return "Rechazada"
+    case "cancelled":
+      return "Cancelada"
+    default:
+      return "Pendiente"
+  }
+}
+
+function formatRequestDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return new Intl.DateTimeFormat("es-ES", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date)
+}
+
+function formatChangeValue(value: unknown): string {
+  if (value === null || value === undefined || value === "") return "—"
+  return String(value)
+}
+
 export default function ProfileDashboard() {
   const { language, toggleLanguage } = useLanguage();
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
@@ -103,6 +162,12 @@ export default function ProfileDashboard() {
   const [completedToday, setCompletedToday] = useState<number>(0)
   const [completedLoading, setCompletedLoading] = useState<boolean>(true)
   const [leaderboardCounts, setLeaderboardCounts] = useState<Map<string, number>>(new Map())
+
+  const [requestModalOpen, setRequestModalOpen] = useState(false)
+  const [myRequests, setMyRequests] = useState<ProfileChangeRequest[]>([])
+  const [requestsLoading, setRequestsLoading] = useState(false)
+  const [requestsError, setRequestsError] = useState<string | null>(null)
+  const [cancellingRequestId, setCancellingRequestId] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false;
@@ -259,6 +324,62 @@ export default function ProfileDashboard() {
     { total: 0, completed: 0, inProgress: 0, pending: 0 }
   )
 
+  const reloadMyRequests = async () => {
+    if (!user?.id) {
+      setMyRequests([])
+      return
+    }
+
+    setRequestsLoading(true)
+    setRequestsError(null)
+
+    try {
+      const data = await getMyProfileChangeRequests()
+      setMyRequests(data)
+    } catch (err) {
+      setRequestsError(err instanceof Error ? err.message : "No se pudieron cargar tus solicitudes.")
+      setMyRequests([])
+    } finally {
+      setRequestsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    reloadMyRequests()
+  }, [user?.id])
+
+  const handleRequestCreated = (request: ProfileChangeRequest) => {
+    setMyRequests((prev) => [request, ...prev])
+  }
+
+  const handleCancelRequest = async (requestId: string) => {
+    if (typeof window !== "undefined") {
+      const confirmed = window.confirm("¿Cancelar esta solicitud?")
+      if (!confirmed) return
+    }
+
+    setCancellingRequestId(requestId)
+
+    try {
+      const updated = await cancelProfileChangeRequest(requestId)
+      setMyRequests((prev) =>
+        prev.map((request) => (request.id_request === requestId ? updated : request))
+      )
+    } catch (err) {
+      setRequestsError(err instanceof Error ? err.message : "No se pudo cancelar la solicitud.")
+    } finally {
+      setCancellingRequestId(null)
+    }
+  }
+
+  const profileSnapshot = {
+    name: profile?.name ?? user?.name ?? "",
+    lastname: profile?.lastname ?? user?.lastname ?? "",
+    email: profile?.email ?? user?.email ?? "",
+    skill: profile?.skill ?? null,
+    area: profile?.area ?? null,
+  }
+
   return (
     <div className="w-full px-4 sm:px-6 lg:px-10 pt-0 pb-4 max-w-350 mx-auto overflow-x-hidden">
 
@@ -334,9 +455,92 @@ export default function ProfileDashboard() {
             </div>
           </Card>
 
-          <Button className="bg-blue-600 hover:bg-blue-700 text-white rounded-xl py-3 sm:py-4 text-sm w-full">
+          <Button
+            type="button"
+            onClick={() => setRequestModalOpen(true)}
+            className="bg-blue-600 hover:bg-blue-700 text-white rounded-xl py-3 sm:py-4 text-sm w-full"
+          >
             Request Modification
           </Button>
+
+          <Card className="rounded-2xl shadow-sm p-4 sm:p-5 border border-gray-100">
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="font-semibold text-sm sm:text-base">Mis solicitudes</h2>
+              <span className="text-xs text-gray-400">
+                {requestsLoading ? "Cargando..." : `${myRequests.length} registradas`}
+              </span>
+            </div>
+
+            {requestsError && (
+              <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-600">
+                {requestsError}
+              </p>
+            )}
+
+            <div className="mt-3 flex flex-col gap-2">
+              {requestsLoading ? (
+                <p className="text-xs text-gray-500">Cargando solicitudes...</p>
+              ) : myRequests.length === 0 ? (
+                <p className="text-xs text-gray-500">No has enviado solicitudes todavía.</p>
+              ) : (
+                myRequests.slice(0, 5).map((request) => {
+                  const proposed = request.proposedChanges ?? {}
+                  const fieldsChanged = Object.keys(proposed)
+                  const isCancelling = cancellingRequestId === request.id_request
+
+                  return (
+                    <div
+                      key={request.id_request}
+                      className="rounded-xl border border-gray-100 bg-white px-3 py-2 text-xs shadow-sm"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${getRequestStatusStyles(
+                            request.status
+                          )}`}
+                        >
+                          {getRequestStatusLabel(request.status)}
+                        </span>
+                        <span className="text-[10px] text-gray-400">
+                          {formatRequestDate(request.createdAt)}
+                        </span>
+                      </div>
+
+                      <ul className="mt-2 space-y-0.5 text-[11px] text-slate-700">
+                        {fieldsChanged.map((field) => (
+                          <li key={field} className="truncate">
+                            <span className="font-medium text-slate-900">
+                              {PROFILE_REQUEST_FIELD_LABELS[field] ?? field}:
+                            </span>{" "}
+                            {formatChangeValue((proposed as Record<string, unknown>)[field])}
+                          </li>
+                        ))}
+                      </ul>
+
+                      {request.status === "rejected" && request.reviewNote && (
+                        <p className="mt-2 rounded-md bg-red-50 px-2 py-1 text-[11px] text-red-700">
+                          Motivo: {request.reviewNote}
+                        </p>
+                      )}
+
+                      {request.status === "pending" && (
+                        <div className="mt-2 flex justify-end">
+                          <button
+                            type="button"
+                            disabled={isCancelling}
+                            onClick={() => handleCancelRequest(request.id_request)}
+                            className="text-[11px] font-medium text-red-600 transition hover:text-red-800 disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            {isCancelling ? "Cancelando..." : "Cancelar"}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )
+                })
+              )}
+            </div>
+          </Card>
 
           <Button
             type="button"
@@ -347,6 +551,13 @@ export default function ProfileDashboard() {
             {language === "en" ? "Switch to Spanish" : "Cambiar a Ingles"}
           </Button>
         </div>
+
+        <RequestModificationModal
+          open={requestModalOpen}
+          onClose={() => setRequestModalOpen(false)}
+          current={profileSnapshot}
+          onCreated={handleRequestCreated}
+        />
 
         {!isAdmin && (
           <div className="md:col-span-4 lg:col-span-6 flex flex-col">

--- a/src/app/(app)/projects/[projectId]/progress/page.tsx
+++ b/src/app/(app)/projects/[projectId]/progress/page.tsx
@@ -1,0 +1,519 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { useParams } from "next/navigation"
+import { CheckCircle2, AlertTriangle, Trash2 } from "lucide-react"
+
+import {
+  ProgressEntry,
+  ProgressEntryType,
+  createProjectProgressEntry,
+  deleteProgressEntry,
+  getProjectProgressEntries,
+} from "@/services/progressEntriesService"
+import {
+  BackendSprint,
+  getProjectSprints,
+} from "@/services/milestonesService"
+import { getProjects } from "@/services/projectService"
+import { slugify } from "@/lib/slug"
+import { useAuth } from "@/hooks/useAuth"
+
+type FilterValue = "all" | ProgressEntryType
+
+function formatDateTime(iso: string): string {
+  const date = new Date(iso)
+
+  if (Number.isNaN(date.getTime())) {
+    return iso
+  }
+
+  return date.toLocaleString("es-MX", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+export default function ProjectProgressEntriesPage() {
+  const params = useParams()
+  const routeProjectId = params.projectId as string
+  const { user } = useAuth()
+
+  const [resolvedProject, setResolvedProject] = useState<{ id: string; name: string } | null>(null)
+  const [projectError, setProjectError] = useState<string | null>(null)
+  const [resolvingProject, setResolvingProject] = useState(true)
+
+  const [entries, setEntries] = useState<ProgressEntry[]>([])
+  const [sprints, setSprints] = useState<BackendSprint[]>([])
+  const [filter, setFilter] = useState<FilterValue>("all")
+  const [sprintFilter, setSprintFilter] = useState<string>("")
+
+  const [loading, setLoading] = useState(true)
+  const [listError, setListError] = useState<string | null>(null)
+
+  const [type, setType] = useState<ProgressEntryType>("progress")
+  const [description, setDescription] = useState("")
+  const [date, setDate] = useState("")
+  const [sprintId, setSprintId] = useState<string>("")
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const projectId = resolvedProject?.id ?? null
+
+  useEffect(() => {
+    let isMounted = true
+
+    const resolve = async () => {
+      setResolvingProject(true)
+      setProjectError(null)
+
+      try {
+        const projects = await getProjects()
+        const match = projects.find(
+          (project) => project.id === routeProjectId || slugify(project.name) === routeProjectId
+        )
+
+        if (!isMounted) return
+
+        if (!match) {
+          setProjectError("No se encontró el proyecto solicitado.")
+          setResolvedProject(null)
+          return
+        }
+
+        setResolvedProject({ id: match.id, name: match.name })
+      } catch (error) {
+        if (!isMounted) return
+        const message = error instanceof Error ? error.message : "No se pudo resolver el proyecto."
+        setProjectError(message)
+        setResolvedProject(null)
+      } finally {
+        if (isMounted) setResolvingProject(false)
+      }
+    }
+
+    resolve()
+
+    return () => {
+      isMounted = false
+    }
+  }, [routeProjectId])
+
+  const loadEntries = useCallback(async () => {
+    if (!projectId) return
+
+    setLoading(true)
+    setListError(null)
+
+    try {
+      const data = await getProjectProgressEntries(projectId, {
+        type: filter === "all" ? undefined : filter,
+        sprintId: sprintFilter || undefined,
+      })
+
+      setEntries(data)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Error al cargar los registros."
+      setListError(message)
+      setEntries([])
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId, filter, sprintFilter])
+
+  useEffect(() => {
+    loadEntries()
+  }, [loadEntries])
+
+  useEffect(() => {
+    if (!projectId) return
+    let isMounted = true
+
+    const loadSprints = async () => {
+      try {
+        const data = await getProjectSprints(projectId)
+        if (isMounted) {
+          setSprints(data)
+        }
+      } catch (error) {
+        console.error("Error cargando sprints del proyecto:", error)
+        if (isMounted) {
+          setSprints([])
+        }
+      }
+    }
+
+    loadSprints()
+
+    return () => {
+      isMounted = false
+    }
+  }, [projectId])
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!projectId) return
+
+    const trimmed = description.trim()
+    if (!trimmed) {
+      setSubmitError("La descripción es obligatoria.")
+      return
+    }
+
+    setSubmitting(true)
+    setSubmitError(null)
+
+    try {
+      await createProjectProgressEntry(projectId, {
+        type,
+        description: trimmed,
+        date: date ? new Date(date).toISOString() : undefined,
+        id_sprint: sprintId || null,
+      })
+
+      setDescription("")
+      setDate("")
+      setSprintId("")
+      setType("progress")
+      await loadEntries()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "No se pudo registrar."
+      setSubmitError(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (entryId: string) => {
+    if (typeof window !== "undefined") {
+      const confirmed = window.confirm("¿Eliminar este registro?")
+      if (!confirmed) return
+    }
+
+    setDeletingId(entryId)
+
+    try {
+      await deleteProgressEntry(entryId)
+      setEntries((prev) => prev.filter((entry) => entry.id_entry !== entryId))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "No se pudo eliminar el registro."
+      setListError(message)
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  const sprintNameById = useMemo(() => {
+    return sprints.reduce<Record<string, string>>((acc, sprint) => {
+      acc[sprint.id_sprint] = sprint.name
+      return acc
+    }, {})
+  }, [sprints])
+
+  const counts = useMemo(() => {
+    return entries.reduce(
+      (acc, entry) => {
+        acc.total += 1
+        if (entry.type === "progress") acc.progress += 1
+        else acc.blockers += 1
+        return acc
+      },
+      { total: 0, progress: 0, blockers: 0 }
+    )
+  }, [entries])
+
+  if (resolvingProject) {
+    return (
+      <div className="flex min-h-screen w-full items-center justify-center px-8 py-8">
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-zinc-300 border-t-slate-900" />
+      </div>
+    )
+  }
+
+  if (projectError || !resolvedProject) {
+    return (
+      <div className="min-h-screen w-full px-8 py-8">
+        <Link
+          href="/projects"
+          className="text-sm text-gray-500 transition hover:text-black"
+        >
+          ← Back to Projects
+        </Link>
+        <div className="mt-6 rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {projectError ?? "No se encontró el proyecto solicitado."}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen w-full px-8 py-8">
+      <div className="mb-6">
+        <Link
+          href="/projects"
+          className="text-sm text-gray-500 transition hover:text-black"
+        >
+          ← Back to Projects
+        </Link>
+
+        <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h1 className="text-4xl font-bold text-slate-800">Progress &amp; Blockers</h1>
+            <p className="mt-1 text-sm text-slate-500">
+              {resolvedProject.name} · Registra avances y bloqueadores. La lista se ordena del más reciente al más antiguo.
+            </p>
+          </div>
+
+          <Link
+            href={`/projects/${routeProjectId}/tasks`}
+            className="rounded-2xl border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:shadow-md"
+          >
+            View Tasks
+          </Link>
+        </div>
+      </div>
+
+      <section className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <SummaryCard label="Total" value={counts.total} tone="neutral" />
+        <SummaryCard label="Avances" value={counts.progress} tone="progress" />
+        <SummaryCard label="Bloqueadores" value={counts.blockers} tone="blocker" />
+      </section>
+
+      <section className="mb-8 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-800">Nuevo registro</h2>
+        <p className="mb-4 text-xs text-slate-500">
+          Reporta un avance del proyecto o un bloqueador que esté afectando el progreso.
+        </p>
+
+        <form className="space-y-4" onSubmit={handleCreate}>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <label className="flex flex-col text-sm text-slate-700">
+              <span className="mb-1 font-medium">Tipo</span>
+              <select
+                value={type}
+                onChange={(event) => setType(event.target.value as ProgressEntryType)}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              >
+                <option value="progress">Avance</option>
+                <option value="blocker">Bloqueador</option>
+              </select>
+            </label>
+
+            <label className="flex flex-col text-sm text-slate-700">
+              <span className="mb-1 font-medium">Fecha (opcional)</span>
+              <input
+                type="datetime-local"
+                value={date}
+                onChange={(event) => setDate(event.target.value)}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+
+            <label className="flex flex-col text-sm text-slate-700">
+              <span className="mb-1 font-medium">Sprint (opcional)</span>
+              <select
+                value={sprintId}
+                onChange={(event) => setSprintId(event.target.value)}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              >
+                <option value="">Sin sprint</option>
+                {sprints.map((sprint) => (
+                  <option key={sprint.id_sprint} value={sprint.id_sprint}>
+                    {sprint.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label className="flex flex-col text-sm text-slate-700">
+            <span className="mb-1 font-medium">Descripción</span>
+            <textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={3}
+              placeholder="Ej: Se integró el login con JWT / Bloqueado por accesos a Azure"
+              className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+            />
+          </label>
+
+          {submitError && (
+            <p className="text-sm text-red-600">{submitError}</p>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-2xl bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+            >
+              {submitting ? "Guardando..." : "Agregar registro"}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-slate-800">Historial</h2>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="inline-flex overflow-hidden rounded-md border border-zinc-200 bg-zinc-50 text-xs font-medium text-slate-600">
+              {(["all", "progress", "blocker"] as FilterValue[]).map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setFilter(value)}
+                  className={`px-3 py-1.5 transition ${
+                    filter === value
+                      ? "bg-slate-900 text-white"
+                      : "hover:bg-zinc-100"
+                  }`}
+                >
+                  {value === "all"
+                    ? "Todos"
+                    : value === "progress"
+                    ? "Avances"
+                    : "Bloqueadores"}
+                </button>
+              ))}
+            </div>
+
+            <select
+              value={sprintFilter}
+              onChange={(event) => setSprintFilter(event.target.value)}
+              className="rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-xs text-slate-700 focus:border-slate-400 focus:outline-none"
+            >
+              <option value="">Todos los sprints</option>
+              {sprints.map((sprint) => (
+                <option key={sprint.id_sprint} value={sprint.id_sprint}>
+                  {sprint.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {listError && (
+          <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {listError}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-10">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-slate-900" />
+          </div>
+        ) : entries.length === 0 ? (
+          <p className="py-10 text-center text-sm text-slate-500">
+            Aún no hay registros para este filtro.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {entries.map((entry) => {
+              const canDelete = user?.id === entry.createdBy
+              const isDeleting = deletingId === entry.id_entry
+              const sprintName = entry.id_sprint ? sprintNameById[entry.id_sprint] : null
+
+              return (
+                <li
+                  key={entry.id_entry}
+                  className={`flex flex-col gap-2 rounded-lg border p-4 sm:flex-row sm:items-start sm:justify-between ${
+                    entry.type === "progress"
+                      ? "border-emerald-200 bg-emerald-50/40"
+                      : "border-amber-200 bg-amber-50/40"
+                  }`}
+                >
+                  <div className="flex flex-1 items-start gap-3">
+                    <div
+                      className={`mt-0.5 flex h-8 w-8 flex-none items-center justify-center rounded-full ${
+                        entry.type === "progress"
+                          ? "bg-emerald-100 text-emerald-700"
+                          : "bg-amber-100 text-amber-700"
+                      }`}
+                      aria-hidden
+                    >
+                      {entry.type === "progress" ? (
+                        <CheckCircle2 className="h-4 w-4" />
+                      ) : (
+                        <AlertTriangle className="h-4 w-4" />
+                      )}
+                    </div>
+
+                    <div className="flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+                            entry.type === "progress"
+                              ? "bg-emerald-100 text-emerald-700"
+                              : "bg-amber-100 text-amber-700"
+                          }`}
+                        >
+                          {entry.type === "progress" ? "Avance" : "Bloqueador"}
+                        </span>
+                        <span className="text-xs text-slate-500">
+                          {formatDateTime(entry.date)}
+                        </span>
+                        {sprintName && (
+                          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-600">
+                            Sprint · {sprintName}
+                          </span>
+                        )}
+                      </div>
+
+                      <p className="mt-2 whitespace-pre-line text-sm text-slate-700">
+                        {entry.description}
+                      </p>
+                    </div>
+                  </div>
+
+                  {canDelete && (
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(entry.id_entry)}
+                      disabled={isDeleting}
+                      className="self-start rounded-md border border-transparent p-1.5 text-slate-400 transition hover:border-red-200 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-60"
+                      aria-label="Eliminar registro"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}
+
+interface SummaryCardProps {
+  label: string
+  value: number
+  tone: "neutral" | "progress" | "blocker"
+}
+
+function SummaryCard({ label, value, tone }: SummaryCardProps) {
+  const toneClasses =
+    tone === "progress"
+      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+      : tone === "blocker"
+      ? "border-amber-200 bg-amber-50 text-amber-700"
+      : "border-zinc-200 bg-white text-slate-700"
+
+  return (
+    <div className={`rounded-xl border p-4 shadow-sm ${toneClasses}`}>
+      <p className="text-xs font-medium uppercase tracking-wide opacity-80">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-bold">{value}</p>
+    </div>
+  )
+}

--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -360,12 +360,21 @@ function ProjectCard({ project, usersById, onEdit }: ProjectCardProps) {
         </div>
       </div>
 
-      <Link
-        href={`/projects/${slugify(project.name)}/tasks`}
-        className="inline-flex w-full items-center justify-center rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-100"
-      >
-        View Tasks
-      </Link>
+      <div className="flex gap-2">
+        <Link
+          href={`/projects/${slugify(project.name)}/tasks`}
+          className="inline-flex flex-1 items-center justify-center rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-100"
+        >
+          View Tasks
+        </Link>
+
+        <Link
+          href={`/projects/${slugify(project.name)}/progress`}
+          className="inline-flex flex-1 items-center justify-center rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3 text-sm font-semibold text-zinc-700 transition hover:bg-zinc-100"
+        >
+          Progress
+        </Link>
+      </div>
     </article>
   );
 }

--- a/src/components/profile/AdminProfileChangeRequests.tsx
+++ b/src/components/profile/AdminProfileChangeRequests.tsx
@@ -1,0 +1,297 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import {
+  ProfileChangeRequest,
+  ProfileChangeStatus,
+  approveProfileChangeRequest,
+  getAllProfileChangeRequests,
+  rejectProfileChangeRequest,
+} from "@/services/profileChangeRequestService"
+import { UserDirectoryEntry, getUsersDirectory } from "@/services/userService"
+
+const FIELD_LABELS: Record<string, string> = {
+  name: "Nombre",
+  lastname: "Apellido",
+  email: "Email",
+  skill: "Skill",
+  area: "Área",
+}
+
+type ActionState = {
+  id: string | null
+  kind: "approve" | "reject" | null
+}
+
+const dateFormatter = new Intl.DateTimeFormat("es-ES", {
+  dateStyle: "medium",
+  timeStyle: "short",
+})
+
+function formatDate(value: string): string {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : dateFormatter.format(date)
+}
+
+function formatChangeValue(value: unknown): string {
+  if (value === null || value === undefined || value === "") return "—"
+  return String(value)
+}
+
+function statusBadgeStyles(status: ProfileChangeStatus): string {
+  switch (status) {
+    case "approved":
+      return "bg-emerald-100 text-emerald-700"
+    case "rejected":
+      return "bg-red-100 text-red-700"
+    case "cancelled":
+      return "bg-slate-100 text-slate-600"
+    default:
+      return "bg-amber-100 text-amber-700"
+  }
+}
+
+interface RejectModalProps {
+  open: boolean
+  onClose: () => void
+  onConfirm: (note: string) => void
+  submitting: boolean
+}
+
+function RejectModal({ open, onClose, onConfirm, submitting }: RejectModalProps) {
+  const [note, setNote] = useState("")
+
+  useEffect(() => {
+    if (open) {
+      setNote("")
+    }
+  }, [open])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6 backdrop-blur-sm">
+      <div className="w-[min(94vw,28rem)] overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-2xl shadow-slate-900/20">
+        <div className="border-b border-slate-100 px-5 py-4">
+          <p className="text-base font-semibold text-slate-900">Rechazar solicitud</p>
+          <p className="text-xs text-slate-500">El motivo se incluirá en la notificación al usuario (opcional).</p>
+        </div>
+
+        <div className="space-y-4 px-5 py-5">
+          <label className="flex flex-col text-sm text-slate-700">
+            <span className="mb-1 font-medium">Motivo</span>
+            <textarea
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              rows={3}
+              placeholder="Ej: El email ya está en uso por otro miembro."
+              className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+            />
+          </label>
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="rounded-2xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={() => onConfirm(note.trim())}
+              disabled={submitting}
+              className="rounded-2xl bg-red-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+            >
+              {submitting ? "Rechazando..." : "Rechazar"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function AdminProfileChangeRequests() {
+  const [requests, setRequests] = useState<ProfileChangeRequest[]>([])
+  const [usersById, setUsersById] = useState<Record<string, UserDirectoryEntry>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [action, setAction] = useState<ActionState>({ id: null, kind: null })
+
+  const [rejectTarget, setRejectTarget] = useState<string | null>(null)
+
+  const loadAll = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const [requestsData, directory] = await Promise.all([
+        getAllProfileChangeRequests("pending"),
+        getUsersDirectory().catch(() => [] as UserDirectoryEntry[]),
+      ])
+
+      setRequests(requestsData)
+      setUsersById(
+        directory.reduce<Record<string, UserDirectoryEntry>>((acc, entry) => {
+          acc[entry.id] = entry
+          return acc
+        }, {})
+      )
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudieron cargar las solicitudes.")
+      setRequests([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    loadAll()
+  }, [loadAll])
+
+  const handleApprove = async (requestId: string) => {
+    setAction({ id: requestId, kind: "approve" })
+    setError(null)
+
+    try {
+      await approveProfileChangeRequest(requestId)
+      setRequests((prev) => prev.filter((entry) => entry.id_request !== requestId))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo aprobar la solicitud.")
+    } finally {
+      setAction({ id: null, kind: null })
+    }
+  }
+
+  const handleReject = async (note: string) => {
+    if (!rejectTarget) return
+
+    setAction({ id: rejectTarget, kind: "reject" })
+    setError(null)
+
+    try {
+      await rejectProfileChangeRequest(rejectTarget, note || undefined)
+      const id = rejectTarget
+      setRequests((prev) => prev.filter((entry) => entry.id_request !== id))
+      setRejectTarget(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo rechazar la solicitud.")
+    } finally {
+      setAction({ id: null, kind: null })
+    }
+  }
+
+  const fmtRequester = useMemo(() => {
+    return (id: string) => {
+      const user = usersById[id]
+      if (!user) return id.slice(0, 8)
+      const name = `${user.name ?? ""} ${user.lastname ?? ""}`.trim()
+      return name ? `${name} · ${user.email}` : user.email
+    }
+  }, [usersById])
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-base sm:text-lg font-semibold">Solicitudes de modificación pendientes</h2>
+        <div className="flex items-center gap-3 text-xs text-gray-400">
+          <span>{loading ? "Cargando..." : `${requests.length} pendientes`}</span>
+          <button
+            type="button"
+            onClick={loadAll}
+            className="rounded-md border border-slate-200 px-2 py-1 text-[11px] font-medium text-slate-600 transition hover:bg-slate-100"
+          >
+            Refrescar
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+          {error}
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-col gap-3">
+        {loading ? (
+          <p className="text-sm text-gray-500">Cargando solicitudes...</p>
+        ) : requests.length === 0 ? (
+          <p className="text-sm text-gray-500">No hay solicitudes pendientes.</p>
+        ) : (
+          requests.map((request) => {
+            const proposed = request.proposedChanges ?? {}
+            const fieldsChanged = Object.keys(proposed)
+            const isApproving = action.id === request.id_request && action.kind === "approve"
+            const isRejecting = action.id === request.id_request && action.kind === "reject"
+
+            return (
+              <article
+                key={request.id_request}
+                className="rounded-xl border border-gray-100 bg-white px-4 py-3 shadow-sm"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold text-slate-900 truncate">
+                      {fmtRequester(request.id_user)}
+                    </p>
+                    <p className="text-[11px] text-slate-500">
+                      Enviada {formatDate(request.createdAt)}
+                    </p>
+                  </div>
+
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusBadgeStyles(
+                      request.status
+                    )}`}
+                  >
+                    {request.status}
+                  </span>
+                </div>
+
+                <ul className="mt-3 grid grid-cols-1 gap-1 text-xs text-slate-700 sm:grid-cols-2">
+                  {fieldsChanged.map((field) => (
+                    <li key={field} className="rounded-md bg-slate-50 px-2 py-1">
+                      <span className="font-medium text-slate-900">
+                        {FIELD_LABELS[field] ?? field}:
+                      </span>{" "}
+                      {formatChangeValue((proposed as Record<string, unknown>)[field])}
+                    </li>
+                  ))}
+                </ul>
+
+                <div className="mt-3 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setRejectTarget(request.id_request)}
+                    disabled={isApproving || isRejecting}
+                    className="rounded-md border border-red-200 px-3 py-1.5 text-xs font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    Rechazar
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleApprove(request.id_request)}
+                    disabled={isApproving || isRejecting}
+                    className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+                  >
+                    {isApproving ? "Aprobando..." : "Aprobar"}
+                  </button>
+                </div>
+              </article>
+            )
+          })
+        )}
+      </div>
+
+      <RejectModal
+        open={rejectTarget !== null}
+        onClose={() => setRejectTarget(null)}
+        onConfirm={handleReject}
+        submitting={action.kind === "reject"}
+      />
+    </>
+  )
+}

--- a/src/components/profile/RequestModificationModal.tsx
+++ b/src/components/profile/RequestModificationModal.tsx
@@ -1,0 +1,273 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded"
+
+import {
+  ProfileChangeFields,
+  ProfileChangeRequest,
+  createProfileChangeRequest,
+} from "@/services/profileChangeRequestService"
+
+interface CurrentProfile {
+  name: string
+  lastname: string
+  email: string
+  skill: string | null
+  area: string | null
+}
+
+interface RequestModificationModalProps {
+  open: boolean
+  onClose: () => void
+  current: CurrentProfile
+  onCreated?: (request: ProfileChangeRequest) => void
+}
+
+type FormState = {
+  name: string
+  lastname: string
+  email: string
+  skill: string
+  area: string
+}
+
+function buildInitialForm(current: CurrentProfile): FormState {
+  return {
+    name: current.name ?? "",
+    lastname: current.lastname ?? "",
+    email: current.email ?? "",
+    skill: current.skill ?? "",
+    area: current.area ?? "",
+  }
+}
+
+function diffChanges(initial: FormState, next: FormState, current: CurrentProfile): ProfileChangeFields {
+  const changes: ProfileChangeFields = {}
+
+  const trimmedName = next.name.trim()
+  if (trimmedName !== (current.name ?? "").trim()) {
+    changes.name = trimmedName
+  }
+
+  const trimmedLastname = next.lastname.trim()
+  if (trimmedLastname !== (current.lastname ?? "").trim()) {
+    changes.lastname = trimmedLastname
+  }
+
+  const trimmedEmail = next.email.trim().toLowerCase()
+  if (trimmedEmail !== (current.email ?? "").trim().toLowerCase()) {
+    changes.email = trimmedEmail
+  }
+
+  const trimmedSkill = next.skill.trim()
+  const currentSkill = (current.skill ?? "").trim()
+  if (trimmedSkill !== currentSkill) {
+    changes.skill = trimmedSkill === "" ? null : trimmedSkill
+  }
+
+  const trimmedArea = next.area.trim()
+  const currentArea = (current.area ?? "").trim()
+  if (trimmedArea !== currentArea) {
+    changes.area = trimmedArea === "" ? null : trimmedArea
+  }
+
+  return changes
+}
+
+export default function RequestModificationModal({
+  open,
+  onClose,
+  current,
+  onCreated,
+}: RequestModificationModalProps) {
+  const initial = useMemo(() => buildInitialForm(current), [current])
+  const [form, setForm] = useState<FormState>(initial)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setForm(initial)
+      setError(null)
+    }
+  }, [open, initial])
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && open) {
+        onClose()
+      }
+    }
+
+    window.addEventListener("keydown", handleEscape)
+    return () => window.removeEventListener("keydown", handleEscape)
+  }, [open, onClose])
+
+  const changes = useMemo(() => diffChanges(initial, form, current), [initial, form, current])
+  const hasChanges = Object.keys(changes).length > 0
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!hasChanges) {
+      setError("No has hecho ningún cambio.")
+      return
+    }
+
+    if (changes.name !== undefined && !changes.name) {
+      setError("El nombre no puede quedar vacío.")
+      return
+    }
+
+    if (changes.lastname !== undefined && !changes.lastname) {
+      setError("El apellido no puede quedar vacío.")
+      return
+    }
+
+    if (changes.email !== undefined) {
+      const emailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(changes.email)
+      if (!emailOk) {
+        setError("El email no tiene un formato válido.")
+        return
+      }
+    }
+
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      const created = await createProfileChangeRequest(changes)
+      onCreated?.(created)
+      onClose()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "No se pudo crear la solicitud."
+      setError(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6 backdrop-blur-sm">
+      <div className="w-[min(94vw,32rem)] overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-2xl shadow-slate-900/20">
+        <div className="flex items-center justify-between border-b border-slate-100 px-5 py-4">
+          <div>
+            <p className="text-base font-semibold text-slate-900">Solicitar modificación de perfil</p>
+            <p className="text-xs text-slate-500">
+              Tus cambios entran a revisión por un administrador antes de aplicarse.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+            aria-label="Cerrar"
+          >
+            <CloseRoundedIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4 px-5 py-5">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="flex flex-col text-sm text-slate-700">
+              <span className="mb-1 font-medium">Nombre</span>
+              <input
+                type="text"
+                value={form.name}
+                onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+
+            <label className="flex flex-col text-sm text-slate-700">
+              <span className="mb-1 font-medium">Apellido</span>
+              <input
+                type="text"
+                value={form.lastname}
+                onChange={(event) => setForm((prev) => ({ ...prev, lastname: event.target.value }))}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col text-sm text-slate-700">
+            <span className="mb-1 font-medium">Email</span>
+            <input
+              type="email"
+              value={form.email}
+              onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+              className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+            />
+          </label>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="flex flex-col text-sm text-slate-700">
+              <span className="mb-1 font-medium">
+                Skill principal <span className="text-xs text-slate-400">(opcional)</span>
+              </span>
+              <input
+                type="text"
+                value={form.skill}
+                placeholder="Ej: React"
+                onChange={(event) => setForm((prev) => ({ ...prev, skill: event.target.value }))}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+
+            <label className="flex flex-col text-sm text-slate-700">
+              <span className="mb-1 font-medium">
+                Área <span className="text-xs text-slate-400">(opcional)</span>
+              </span>
+              <input
+                type="text"
+                value={form.area}
+                placeholder="Ej: Frontend, QA"
+                onChange={(event) => setForm((prev) => ({ ...prev, area: event.target.value }))}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+          </div>
+
+          <div className="rounded-xl border border-slate-100 bg-slate-50 px-3 py-2 text-xs text-slate-600">
+            {hasChanges ? (
+              <>
+                <span className="font-semibold">Cambios pendientes:</span>{" "}
+                {Object.keys(changes).join(", ")}
+              </>
+            ) : (
+              "Edita uno o más campos para habilitar el envío."
+            )}
+          </div>
+
+          {error && (
+            <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-2xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+            >
+              Cancelar
+            </button>
+
+            <button
+              type="submit"
+              disabled={submitting || !hasChanges}
+              className="rounded-2xl bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+            >
+              {submitting ? "Enviando..." : "Enviar solicitud"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/notifications/NotificationCenter.tsx
+++ b/src/components/ui/notifications/NotificationCenter.tsx
@@ -17,6 +17,10 @@ const CATEGORY_LABELS: Record<string, string> = {
   admin_user_created: "Admin",
   admin_user_updated: "Admin",
   admin_user_deleted: "Admin",
+  profile_change_requested: "Perfil · solicitud",
+  profile_change_approved: "Perfil · aprobada",
+  profile_change_rejected: "Perfil · rechazada",
+  profile_change_cancelled: "Perfil · cancelada",
 }
 
 const dateFormatter = new Intl.DateTimeFormat("es-ES", {

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -12,6 +12,10 @@ export type NotificationCategory =
   | "admin_user_created"
   | "admin_user_updated"
   | "admin_user_deleted"
+  | "profile_change_requested"
+  | "profile_change_approved"
+  | "profile_change_rejected"
+  | "profile_change_cancelled"
 
 export interface NotificationRecord {
   id_notification: string

--- a/src/services/profileChangeRequestService.ts
+++ b/src/services/profileChangeRequestService.ts
@@ -1,0 +1,132 @@
+import { API_BASE_URL, getToken } from "@/lib/auth"
+
+type ApiResponse<T> = {
+  success: boolean
+  message?: string
+  data?: T
+}
+
+export type ProfileChangeStatus = "pending" | "approved" | "rejected" | "cancelled"
+
+export interface ProfileChangeFields {
+  name?: string
+  lastname?: string
+  email?: string
+  skill?: string | null
+  area?: string | null
+}
+
+export interface ProfileChangeRequest {
+  id_request: string
+  id_user: string
+  proposedChanges: ProfileChangeFields
+  status: ProfileChangeStatus
+  reviewedBy: string | null
+  reviewNote: string | null
+  createdAt: string
+  reviewedAt: string | null
+}
+
+function authHeaders(): Record<string, string> {
+  const token = getToken()
+
+  if (!token) {
+    throw new Error("Sesión expirada. Inicia sesión nuevamente.")
+  }
+
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  }
+}
+
+async function parseEnvelope<T>(response: Response, fallbackMessage: string): Promise<T> {
+  const payload = (await response.json().catch(() => ({}))) as ApiResponse<T>
+
+  if (!response.ok || !payload.success || payload.data === undefined) {
+    throw new Error(payload.message || fallbackMessage)
+  }
+
+  return payload.data
+}
+
+export async function createProfileChangeRequest(
+  changes: ProfileChangeFields
+): Promise<ProfileChangeRequest> {
+  const response = await fetch(`${API_BASE_URL}/profile-change-requests`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(changes),
+  })
+
+  return parseEnvelope<ProfileChangeRequest>(response, "No se pudo crear la solicitud de modificación.")
+}
+
+export async function getMyProfileChangeRequests(): Promise<ProfileChangeRequest[]> {
+  const response = await fetch(`${API_BASE_URL}/profile-change-requests/me`, {
+    method: "GET",
+    headers: authHeaders(),
+    cache: "no-store",
+  })
+
+  return parseEnvelope<ProfileChangeRequest[]>(response, "No se pudieron obtener tus solicitudes.")
+}
+
+export async function getAllProfileChangeRequests(
+  status?: ProfileChangeStatus
+): Promise<ProfileChangeRequest[]> {
+  const query = status ? `?status=${status}` : ""
+
+  const response = await fetch(`${API_BASE_URL}/profile-change-requests${query}`, {
+    method: "GET",
+    headers: authHeaders(),
+    cache: "no-store",
+  })
+
+  return parseEnvelope<ProfileChangeRequest[]>(response, "No se pudieron obtener las solicitudes.")
+}
+
+export async function approveProfileChangeRequest(requestId: string): Promise<ProfileChangeRequest> {
+  const response = await fetch(`${API_BASE_URL}/profile-change-requests/${requestId}/approve`, {
+    method: "POST",
+    headers: authHeaders(),
+  })
+
+  return parseEnvelope<ProfileChangeRequest>(response, "No se pudo aprobar la solicitud.")
+}
+
+export async function rejectProfileChangeRequest(
+  requestId: string,
+  reviewNote?: string
+): Promise<ProfileChangeRequest> {
+  const body = reviewNote ? JSON.stringify({ reviewNote }) : undefined
+
+  const response = await fetch(`${API_BASE_URL}/profile-change-requests/${requestId}/reject`, {
+    method: "POST",
+    headers: authHeaders(),
+    body,
+  })
+
+  return parseEnvelope<ProfileChangeRequest>(response, "No se pudo rechazar la solicitud.")
+}
+
+export async function cancelProfileChangeRequest(requestId: string): Promise<ProfileChangeRequest> {
+  const response = await fetch(`${API_BASE_URL}/profile-change-requests/${requestId}`, {
+    method: "DELETE",
+    headers: authHeaders(),
+  })
+
+  return parseEnvelope<ProfileChangeRequest>(response, "No se pudo cancelar la solicitud.")
+}
+
+export const PROFILE_CHANGE_FIELDS: Array<{
+  key: keyof ProfileChangeFields
+  label: string
+  nullable: boolean
+}> = [
+  { key: "name", label: "Nombre", nullable: false },
+  { key: "lastname", label: "Apellido", nullable: false },
+  { key: "email", label: "Email", nullable: false },
+  { key: "skill", label: "Skill principal", nullable: true },
+  { key: "area", label: "Área", nullable: true },
+]

--- a/src/services/progressEntriesService.ts
+++ b/src/services/progressEntriesService.ts
@@ -1,0 +1,96 @@
+import { API_BASE_URL, getToken } from "@/lib/auth"
+
+type ApiResponse<T> = {
+  success: boolean
+  message?: string
+  data?: T
+}
+
+export type ProgressEntryType = "progress" | "blocker"
+
+export interface ProgressEntry {
+  id_entry: string
+  type: ProgressEntryType
+  description: string
+  date: string
+  id_project: string
+  id_sprint: string | null
+  createdBy: string
+  createdAt: string
+}
+
+export interface CreateProgressEntryPayload {
+  type: ProgressEntryType
+  description: string
+  date?: string
+  id_sprint?: string | null
+}
+
+export interface ListProgressEntriesFilters {
+  type?: ProgressEntryType
+  sprintId?: string
+}
+
+function authHeaders(): Record<string, string> {
+  const token = getToken()
+
+  if (!token) {
+    throw new Error("Sesión expirada. Inicia sesión nuevamente.")
+  }
+
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  }
+}
+
+async function parseEnvelope<T>(response: Response, fallbackMessage: string): Promise<T> {
+  const payload = (await response.json().catch(() => ({}))) as ApiResponse<T>
+
+  if (!response.ok || !payload.success || payload.data === undefined) {
+    throw new Error(payload.message || fallbackMessage)
+  }
+
+  return payload.data
+}
+
+export async function getProjectProgressEntries(
+  projectId: string,
+  filters: ListProgressEntriesFilters = {}
+): Promise<ProgressEntry[]> {
+  const params = new URLSearchParams()
+  if (filters.type) params.set("type", filters.type)
+  if (filters.sprintId) params.set("sprintId", filters.sprintId)
+
+  const query = params.toString() ? `?${params.toString()}` : ""
+
+  const response = await fetch(`${API_BASE_URL}/projects/${projectId}/progress-entries${query}`, {
+    method: "GET",
+    headers: authHeaders(),
+    cache: "no-store",
+  })
+
+  return parseEnvelope<ProgressEntry[]>(response, "No se pudieron obtener los avances y bloqueadores.")
+}
+
+export async function createProjectProgressEntry(
+  projectId: string,
+  payload: CreateProgressEntryPayload
+): Promise<ProgressEntry> {
+  const response = await fetch(`${API_BASE_URL}/projects/${projectId}/progress-entries`, {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  })
+
+  return parseEnvelope<ProgressEntry>(response, "No se pudo registrar el avance o bloqueador.")
+}
+
+export async function deleteProgressEntry(entryId: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/progress-entries/${entryId}`, {
+    method: "DELETE",
+    headers: authHeaders(),
+  })
+
+  await parseEnvelope<unknown>(response, "No se pudo eliminar el registro.")
+}


### PR DESCRIPTION
## Resumen

Promueve a producción los dos tickets ya integrados en `dev` después del último deploy:

- **PM-111** — registro de avances y bloqueadores por proyecto (página nueva `/projects/<slug>/progress` + service)
- **PM-96** — Request Modification de perfil con flujo de aprobación admin (modal, "Mis solicitudes", sección admin en el dashboard, categorías de notificación)

Backend de ambos ya está desplegado en Render desde el merge BackPM #39.

## Test plan

- [ ] Vercel redeploy de `main` queda verde
- [ ] `/projects/<slug>/progress` carga y permite crear avance/bloqueador
- [ ] `/profile` → botón **Request Modification** abre modal, se puede enviar y cancelar
- [ ] `/dashboard/admin` muestra solicitudes pendientes y permite aprobar/rechazar