### PR TITLE
PM-139: Finanzas Fase 1 - resumen financiero, EVM y reporte por proyecto

### DIFF
--- a/src/app/(app)/projects/[projectId]/finance/page.tsx
+++ b/src/app/(app)/projects/[projectId]/finance/page.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useParams } from "next/navigation"
+
+import { getProjects } from "@/services/projectService"
+import { slugify } from "@/lib/slug"
+import FinancialSummaryPanel from "@/components/finance/FinancialSummaryPanel"
+import EvmPanel from "@/components/finance/EvmPanel"
+import ReportPanel from "@/components/finance/ReportPanel"
+
+type FinanceTab = "summary" | "evm" | "report"
+
+const TABS: { key: FinanceTab; label: string }[] = [
+  { key: "summary", label: "Resumen" },
+  { key: "evm", label: "EVM" },
+  { key: "report", label: "Reporte" },
+]
+
+export default function ProjectFinancePage() {
+  const params = useParams()
+  const routeProjectId = params.projectId as string
+
+  const [resolvedProject, setResolvedProject] = useState<{ id: string; name: string } | null>(null)
+  const [projectError, setProjectError] = useState<string | null>(null)
+  const [resolving, setResolving] = useState(true)
+  const [tab, setTab] = useState<FinanceTab>("summary")
+
+  useEffect(() => {
+    let active = true
+
+    const resolve = async () => {
+      setResolving(true)
+      setProjectError(null)
+
+      try {
+        const projects = await getProjects()
+        const match = projects.find(
+          (project) => project.id === routeProjectId || slugify(project.name) === routeProjectId
+        )
+
+        if (!active) return
+
+        if (!match) {
+          setProjectError("No se encontró el proyecto solicitado.")
+          setResolvedProject(null)
+          return
+        }
+
+        setResolvedProject({ id: match.id, name: match.name })
+      } catch (error) {
+        if (!active) return
+        setProjectError(error instanceof Error ? error.message : "No se pudo resolver el proyecto.")
+        setResolvedProject(null)
+      } finally {
+        if (active) setResolving(false)
+      }
+    }
+
+    resolve()
+
+    return () => {
+      active = false
+    }
+  }, [routeProjectId])
+
+  if (resolving) {
+    return (
+      <div className="flex min-h-screen w-full items-center justify-center px-8 py-8">
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-zinc-300 border-t-slate-900" />
+      </div>
+    )
+  }
+
+  if (projectError || !resolvedProject) {
+    return (
+      <div className="min-h-screen w-full px-8 py-8">
+        <Link href="/projects" className="text-sm text-gray-500 transition hover:text-black">
+          ← Back to Projects
+        </Link>
+        <div className="mt-6 rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {projectError ?? "No se encontró el proyecto solicitado."}
+        </div>
+      </div>
+    )
+  }
+
+  const projectId = resolvedProject.id
+
+  return (
+    <div className="min-h-screen w-full px-8 py-8">
+      <div className="mb-6">
+        <Link href="/projects" className="text-sm text-gray-500 transition hover:text-black">
+          ← Back to Projects
+        </Link>
+
+        <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h1 className="text-4xl font-bold text-slate-800">Finanzas</h1>
+            <p className="mt-1 text-sm text-slate-500">
+              {resolvedProject.name} · KPIs financieros, EVM y reporte del proyecto.
+            </p>
+          </div>
+
+          <Link
+            href={`/projects/${routeProjectId}/tasks`}
+            className="rounded-2xl border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:shadow-md"
+          >
+            Ver tareas
+          </Link>
+        </div>
+      </div>
+
+      <div className="mb-6 inline-flex overflow-hidden rounded-md border border-zinc-200 bg-zinc-50 text-sm font-medium text-slate-600">
+        {TABS.map((item) => (
+          <button
+            key={item.key}
+            type="button"
+            onClick={() => setTab(item.key)}
+            className={`px-4 py-2 transition ${
+              tab === item.key ? "bg-slate-900 text-white" : "hover:bg-zinc-100"
+            }`}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "summary" && <FinancialSummaryPanel projectId={projectId} />}
+      {tab === "evm" && <EvmPanel projectId={projectId} />}
+      {tab === "report" && <ReportPanel projectId={projectId} />}
+    </div>
+  )
+}

--- a/src/app/(app)/projects/[projectId]/progress/page.tsx
+++ b/src/app/(app)/projects/[projectId]/progress/page.tsx
@@ -270,12 +270,20 @@ export default function ProjectProgressEntriesPage() {
             </p>
           </div>
 
-          <Link
-            href={`/projects/${routeProjectId}/tasks`}
-            className="rounded-2xl border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:shadow-md"
-          >
-            View Tasks
-          </Link>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href={`/projects/${routeProjectId}/finance`}
+              className="rounded-2xl border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:shadow-md"
+            >
+              Finanzas
+            </Link>
+            <Link
+              href={`/projects/${routeProjectId}/tasks`}
+              className="rounded-2xl border border-gray-300 bg-white px-5 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition hover:shadow-md"
+            >
+              View Tasks
+            </Link>
+          </div>
         </div>
       </div>
 

--- a/src/app/(app)/projects/[projectId]/tasks/page.tsx
+++ b/src/app/(app)/projects/[projectId]/tasks/page.tsx
@@ -5,6 +5,7 @@ import { DragDropContext, type DropResult } from "@hello-pangea/dnd"
 import SummarizeIcon from "@mui/icons-material/Summarize"
 import Tooltip from "@mui/material/Tooltip"
 import { useParams, useSearchParams } from "next/navigation"
+import Link from "next/link"
 
 import SprintBoard from "@/components/sprints/SprintBoard"
 import CreateSprintModal from "@/components/sprints/CreateSprintModal"
@@ -403,6 +404,13 @@ export default function TasksPage() {
         </div>
 
         <div className="flex items-center gap-3 self-start lg:self-auto">
+          <Link
+            href={`/projects/${projectId}/finance`}
+            className="rounded-2xl border border-gray-300 bg-white px-5 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:shadow-md"
+          >
+            Finanzas
+          </Link>
+
           <Tooltip title="Generate Report" arrow placement="top">
             <span>
               <button

--- a/src/components/finance/EvmPanel.tsx
+++ b/src/components/finance/EvmPanel.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Info } from "lucide-react"
+
+import { AcSource, EvmData } from "@/types/finance"
+import { getProjectEvm } from "@/services/financeSummaryService"
+import { formatMoney, formatNumber } from "@/lib/utils"
+import EvmChart from "@/components/ui/graphs/EvmChart"
+
+const AC_SOURCE_LABELS: Record<AcSource, string> = {
+  logged_hours: "Horas registradas (costo real)",
+  member_rates: "Tarifas de miembros (indicativo)",
+  project_monthly_cost: "Costo mensual del proyecto (indicativo)",
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-1 text-xl font-bold text-slate-800">{value}</p>
+    </div>
+  )
+}
+
+/** SPI/CPI: ≥1 es bueno (verde), <1 es malo (rojo). */
+function IndexCard({ label, value }: { label: string; value: number | null }) {
+  const tone =
+    value === null
+      ? "border-zinc-200 bg-white text-slate-800"
+      : value >= 1
+      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+      : "border-red-200 bg-red-50 text-red-700"
+
+  return (
+    <div className={`rounded-xl border p-4 shadow-sm ${tone}`}>
+      <p className="text-xs font-medium uppercase tracking-wide opacity-80">{label}</p>
+      <p className="mt-1 text-xl font-bold">{formatNumber(value, "N/A", 2)}</p>
+    </div>
+  )
+}
+
+export default function EvmPanel({ projectId }: { projectId: string }) {
+  const [data, setData] = useState<EvmData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const evm = await getProjectEvm(projectId)
+        if (active) setData(evm)
+      } catch (err) {
+        if (active) setError(err instanceof Error ? err.message : "No se pudo cargar el análisis EVM.")
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    load()
+
+    return () => {
+      active = false
+    }
+  }, [projectId])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-slate-900" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+    )
+  }
+
+  if (!data) return null
+
+  return (
+    <div className="space-y-6">
+      {/* Índices de desempeño */}
+      <section className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <IndexCard label="SPI · Cronograma" value={data.schedulePerformanceIndex} />
+        <IndexCard label="CPI · Costo" value={data.costPerformanceIndex} />
+        <StatCard label="EAC · Estimado al cierre" value={formatMoney(data.estimateAtCompletion)} />
+        <StatCard label="VAC · Variación al cierre" value={formatMoney(data.varianceAtCompletion)} />
+      </section>
+
+      {/* Valores base */}
+      <section className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard label="PV · Planned Value" value={formatMoney(data.plannedValue)} />
+        <StatCard label="EV · Earned Value" value={formatMoney(data.earnedValue)} />
+        <StatCard label="AC · Actual Cost" value={formatMoney(data.actualCost)} />
+        <StatCard label="Presupuesto" value={formatMoney(data.budget)} />
+      </section>
+
+      {/* Curva-S */}
+      <section className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-lg font-semibold text-slate-800">Curva-S (PV / EV / AC)</h3>
+          {data.acSource && (
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600">
+              AC: {AC_SOURCE_LABELS[data.acSource]}
+            </span>
+          )}
+        </div>
+        <EvmChart series={data.series ?? []} />
+      </section>
+
+      {/* Desglose del Actual Cost */}
+      <section className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard label="Costo de mano de obra" value={formatMoney(data.laborCost)} />
+        <StatCard label="Gastos" value={formatMoney(data.expensesTotal)} />
+        <StatCard label="Horas registradas" value={formatNumber(data.loggedHours)} />
+        <StatCard label="Variación de costo (CV)" value={formatMoney(data.costVariance)} />
+      </section>
+
+      {/* Notas */}
+      {data.notes && data.notes.length > 0 && (
+        <section className="rounded-xl border border-blue-200 bg-blue-50/60 p-4">
+          <div className="flex items-start gap-2">
+            <Info className="mt-0.5 h-4 w-4 flex-none text-blue-600" />
+            <ul className="space-y-1 text-xs text-blue-800">
+              {data.notes.map((note, index) => (
+                <li key={index}>{note}</li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/src/components/finance/FinancialSummaryPanel.tsx
+++ b/src/components/finance/FinancialSummaryPanel.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { AlertTriangle, CheckCircle2, Info } from "lucide-react"
+
+import { FinancialSummary } from "@/types/finance"
+import { getFinancialSummary } from "@/services/financeSummaryService"
+import { formatMoney, formatNumber } from "@/lib/utils"
+import GaugeChart from "@/components/ui/graphs/GaugeChart"
+import BurnChart from "@/components/ui/graphs/BurnChart"
+
+const BILLING_LABELS: Record<string, string> = {
+  fixed_price: "Precio fijo",
+  retainer: "Honorarios mensuales",
+  time_and_materials: "Tiempo y materiales",
+}
+
+function KpiCard({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-1 text-xl font-bold text-slate-800">{value}</p>
+      {hint && <p className="mt-1 text-[11px] text-slate-400">{hint}</p>}
+    </div>
+  )
+}
+
+export default function FinancialSummaryPanel({ projectId }: { projectId: string }) {
+  const [data, setData] = useState<FinancialSummary | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const summary = await getFinancialSummary(projectId)
+        if (active) setData(summary)
+      } catch (err) {
+        if (active) setError(err instanceof Error ? err.message : "No se pudo cargar el resumen financiero.")
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    load()
+
+    return () => {
+      active = false
+    }
+  }, [projectId])
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-slate-900" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+    )
+  }
+
+  if (!data) return null
+
+  const billingLabel = data.billingModel
+    ? BILLING_LABELS[data.billingModel] ?? data.billingModel
+    : "N/A"
+
+  const overBudget = data.projectedOverBudget !== null && data.projectedOverBudget > 0
+
+  return (
+    <div className="space-y-6">
+      {/* Encabezado */}
+      <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <KpiCard label="Presupuesto" value={formatMoney(data.budget)} />
+        <KpiCard label="Costo mensual" value={formatMoney(data.monthlyCost)} />
+        <KpiCard label="Modelo de facturación" value={billingLabel} />
+      </section>
+
+      {/* Gauges */}
+      <section className="grid grid-cols-1 gap-4 rounded-xl border border-zinc-200 bg-white p-6 shadow-sm sm:grid-cols-2">
+        <GaugeChart value={data.budgetConsumedRatio} label="Presupuesto consumido" />
+        <GaugeChart value={data.timeProgressRatio} label="Tiempo transcurrido" warnAt={1.1} dangerAt={1.2} />
+      </section>
+
+      {/* Semáforos */}
+      <section className="flex flex-wrap gap-3">
+        {data.budgetCoversPlannedEnd === true && (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+            <CheckCircle2 className="h-3.5 w-3.5" /> El presupuesto alcanza la fecha fin
+          </span>
+        )}
+        {data.budgetCoversPlannedEnd === false && (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-medium text-red-700">
+            <AlertTriangle className="h-3.5 w-3.5" /> El presupuesto no alcanza la fecha fin
+          </span>
+        )}
+        {overBudget && (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-medium text-red-700">
+            <AlertTriangle className="h-3.5 w-3.5" /> Sobrecosto proyectado: {formatMoney(data.projectedOverBudget)}
+          </span>
+        )}
+      </section>
+
+      {/* KPIs */}
+      <section className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+        <KpiCard label="Gasto estimado" value={formatMoney(data.estimatedSpend)} hint="Proxy: costo mensual × meses" />
+        <KpiCard label="Presupuesto restante" value={formatMoney(data.remainingBudget)} />
+        <KpiCard label="Runway" value={data.runwayMonths !== null ? `${formatNumber(data.runwayMonths)} meses` : "N/A"} />
+        <KpiCard label="Costo por story point" value={formatMoney(data.costPerStoryPoint)} />
+        <KpiCard label="Costo por sprint estimado" value={formatMoney(data.costPerEstimatedSprint)} />
+      </section>
+
+      {/* Burn */}
+      <section className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <h3 className="mb-4 text-lg font-semibold text-slate-800">Burn acumulado</h3>
+        <BurnChart burnSeries={data.burnSeries ?? []} budget={data.budget} />
+      </section>
+
+      {/* Notas */}
+      {data.notes && data.notes.length > 0 && (
+        <section className="rounded-xl border border-blue-200 bg-blue-50/60 p-4">
+          <div className="flex items-start gap-2">
+            <Info className="mt-0.5 h-4 w-4 flex-none text-blue-600" />
+            <ul className="space-y-1 text-xs text-blue-800">
+              {data.notes.map((note, index) => (
+                <li key={index}>{note}</li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}

--- a/src/components/finance/ReportPanel.tsx
+++ b/src/components/finance/ReportPanel.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Download, RefreshCw } from "lucide-react"
+
+import { getProjectReportUrl } from "@/services/reportService"
+
+export default function ReportPanel({ projectId }: { projectId: string }) {
+  const [reloadKey, setReloadKey] = useState(0)
+
+  // URL estable por proyecto (evita recargar el iframe en cada render).
+  // El refresco lo fuerza el `key={reloadKey}` del iframe, que lo remonta
+  // y vuelve a pedir el PDF (el backend responde con Cache-Control: no-store).
+  const inlineUrl = useMemo(() => getProjectReportUrl(projectId, false), [projectId])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-800">Reporte del proyecto</h3>
+          <p className="text-sm text-slate-500">
+            PDF generado por el backend, incluye la sección &quot;Financial Overview&quot;.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setReloadKey((key) => key + 1)}
+            className="inline-flex items-center gap-1.5 rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:shadow-md"
+          >
+            <RefreshCw className="h-4 w-4" /> Actualizar
+          </button>
+          <a
+            href={getProjectReportUrl(projectId, true)}
+            className="inline-flex items-center gap-1.5 rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700"
+          >
+            <Download className="h-4 w-4" /> Descargar PDF
+          </a>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-sm">
+        <iframe
+          key={reloadKey}
+          src={inlineUrl}
+          title="Reporte del proyecto"
+          className="h-[70vh] w-full"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/i18n/LanguageProvider.tsx
+++ b/src/components/i18n/LanguageProvider.tsx
@@ -251,6 +251,35 @@ const esToEnEntries: Array<[string, string]> = [
   ["Poner en marcha un portal central para la incorporación de clientes", "Launch a central portal for customer onboarding"],
   ["Objetivo", "Objective"],
 
+  // Módulo de Finanzas (PM-139)
+  ["Finanzas", "Finance"],
+  ["Resumen", "Summary"],
+  ["Reporte", "Report"],
+  ["KPIs financieros, EVM y reporte del proyecto.", "Financial KPIs, EVM and project report."],
+  ["Burn acumulado", "Cumulative burn"],
+  ["Costo estimado acumulado", "Cumulative estimated cost"],
+  ["Presupuesto consumido", "Budget consumed"],
+  ["Tiempo transcurrido", "Time elapsed"],
+  ["El presupuesto alcanza la fecha fin", "Budget covers the planned end date"],
+  ["El presupuesto no alcanza la fecha fin", "Budget does not cover the planned end date"],
+  ["Sobrecosto proyectado:", "Projected overrun:"],
+  ["Gasto estimado", "Estimated spend"],
+  ["Proxy: costo mensual × meses", "Proxy: monthly cost × months"],
+  ["Presupuesto restante", "Remaining budget"],
+  ["Costo por story point", "Cost per story point"],
+  ["Costo por sprint estimado", "Cost per estimated sprint"],
+  ["Curva-S (PV / EV / AC)", "S-curve (PV / EV / AC)"],
+  ["Costo de mano de obra", "Labor cost"],
+  ["Gastos", "Expenses"],
+  ["Horas registradas", "Logged hours"],
+  ["Variación de costo (CV)", "Cost variance (CV)"],
+  ["Descargar PDF", "Download PDF"],
+  ["Actualizar", "Refresh"],
+  ["No se encontró el proyecto solicitado.", "The requested project was not found."],
+  ["No se pudo resolver el proyecto.", "The project could not be resolved."],
+  ["Sin datos de burn todavía.", "No burn data yet."],
+  ["Sin serie de EVM todavía.", "No EVM series yet."],
+
 ];
 
 const enToEsEntries: Array<[string, string]> = esToEnEntries.map(([es, en]) => [en, es]);

--- a/src/components/ui/graphs/BurnChart.tsx
+++ b/src/components/ui/graphs/BurnChart.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import {
+  Chart as ChartJS,
+  LineElement,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  Tooltip,
+  Legend,
+  Filler,
+} from "chart.js"
+import { Line } from "react-chartjs-2"
+import { BurnPoint } from "@/types/finance"
+import { formatMoney } from "@/lib/utils"
+
+ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend, Filler)
+
+type BurnChartProps = {
+  burnSeries: BurnPoint[]
+  budget: number | null
+}
+
+export default function BurnChart({ burnSeries, budget }: BurnChartProps) {
+  const labels = burnSeries.map((point) => point.month)
+  const hasBudget = budget !== null && budget !== undefined
+
+  const datasets = [
+    {
+      label: "Costo estimado acumulado",
+      data: burnSeries.map((point) => point.cumulativeEstimatedCost),
+      borderColor: "#6366f1",
+      backgroundColor: "rgba(99,102,241,0.12)",
+      fill: true,
+      tension: 0.3,
+      pointRadius: 2,
+      pointHoverRadius: 5,
+      borderWidth: 2,
+      borderDash: [] as number[],
+    },
+    ...(hasBudget
+      ? [
+          {
+            label: "Presupuesto",
+            data: labels.map(() => budget as number),
+            borderColor: "#ef4444",
+            backgroundColor: "transparent",
+            fill: false,
+            tension: 0,
+            pointRadius: 0,
+            pointHoverRadius: 0,
+            borderWidth: 2,
+            borderDash: [6, 6],
+          },
+        ]
+      : []),
+  ]
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: "index" as const, intersect: false },
+    plugins: {
+      legend: { display: true, position: "bottom" as const, labels: { boxWidth: 12, font: { size: 11 } } },
+      tooltip: {
+        backgroundColor: "white",
+        titleColor: "#111",
+        bodyColor: "#111",
+        borderColor: "#e5e7eb",
+        borderWidth: 1,
+        padding: 10,
+        callbacks: {
+          label: (context: { dataset: { label?: string }; raw: unknown }) =>
+            `${context.dataset.label}: ${formatMoney(Number(context.raw))}`,
+        },
+      },
+    },
+    scales: {
+      x: { grid: { display: false }, ticks: { font: { size: 11 } } },
+      y: {
+        beginAtZero: true,
+        grid: { color: "rgba(0,0,0,0.05)" },
+        ticks: {
+          font: { size: 11 },
+          callback: (value: string | number) => formatMoney(Number(value)),
+        },
+      },
+    },
+  }
+
+  if (burnSeries.length === 0) {
+    return <p className="py-10 text-center text-sm text-slate-400">Sin datos de burn todavía.</p>
+  }
+
+  return (
+    <div className="h-64 w-full">
+      <Line data={{ labels, datasets }} options={options} />
+    </div>
+  )
+}

--- a/src/components/ui/graphs/EvmChart.tsx
+++ b/src/components/ui/graphs/EvmChart.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import {
+  Chart as ChartJS,
+  LineElement,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  Tooltip,
+  Legend,
+} from "chart.js"
+import { Line } from "react-chartjs-2"
+import { EvmSeriesPoint } from "@/types/finance"
+import { formatMoney } from "@/lib/utils"
+
+ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend)
+
+type EvmChartProps = {
+  series: EvmSeriesPoint[]
+}
+
+export default function EvmChart({ series }: EvmChartProps) {
+  const labels = series.map((point) => point.month)
+
+  const makeDataset = (key: "pv" | "ev" | "ac", label: string, color: string) => ({
+    label,
+    data: series.map((point) => point[key]),
+    borderColor: color,
+    backgroundColor: color,
+    // No interpolar sobre meses futuros (ev/ac llegan null): se corta la línea.
+    spanGaps: false,
+    tension: 0.3,
+    pointRadius: 2,
+    pointHoverRadius: 5,
+    borderWidth: 2,
+  })
+
+  const datasets = [
+    makeDataset("pv", "PV · Planned Value", "#64748b"),
+    makeDataset("ev", "EV · Earned Value", "#22c55e"),
+    makeDataset("ac", "AC · Actual Cost", "#ef4444"),
+  ]
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: "index" as const, intersect: false },
+    plugins: {
+      legend: { display: true, position: "bottom" as const, labels: { boxWidth: 12, font: { size: 11 } } },
+      tooltip: {
+        backgroundColor: "white",
+        titleColor: "#111",
+        bodyColor: "#111",
+        borderColor: "#e5e7eb",
+        borderWidth: 1,
+        padding: 10,
+        callbacks: {
+          label: (context: { dataset: { label?: string }; raw: unknown }) =>
+            context.raw === null || context.raw === undefined
+              ? `${context.dataset.label}: N/A`
+              : `${context.dataset.label}: ${formatMoney(Number(context.raw))}`,
+        },
+      },
+    },
+    scales: {
+      x: { grid: { display: false }, ticks: { font: { size: 11 } } },
+      y: {
+        beginAtZero: true,
+        grid: { color: "rgba(0,0,0,0.05)" },
+        ticks: {
+          font: { size: 11 },
+          callback: (value: string | number) => formatMoney(Number(value)),
+        },
+      },
+    },
+  }
+
+  if (series.length === 0) {
+    return <p className="py-10 text-center text-sm text-slate-400">Sin serie de EVM todavía.</p>
+  }
+
+  return (
+    <div className="h-72 w-full">
+      <Line data={{ labels, datasets }} options={options} />
+    </div>
+  )
+}

--- a/src/components/ui/graphs/GaugeChart.tsx
+++ b/src/components/ui/graphs/GaugeChart.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { Chart as ChartJS, ArcElement, Tooltip } from "chart.js"
+import { Doughnut } from "react-chartjs-2"
+import { formatRatio } from "@/lib/utils"
+
+ChartJS.register(ArcElement, Tooltip)
+
+type GaugeChartProps = {
+  /** Ratio 0..1 (puede exceder 1: se rellena al 100% y se colorea de alerta). */
+  value: number | null | undefined
+  label?: string
+  /** Umbral amarillo y rojo sobre el ratio. */
+  warnAt?: number
+  dangerAt?: number
+}
+
+export default function GaugeChart({ value, label, warnAt = 0.8, dangerAt = 1 }: GaugeChartProps) {
+  const hasValue = value !== null && value !== undefined && !Number.isNaN(value)
+  const ratio = hasValue ? (value as number) : 0
+  const filled = Math.max(0, Math.min(ratio, 1))
+
+  const color = !hasValue
+    ? "#cbd5e1"
+    : ratio >= dangerAt
+    ? "#ef4444"
+    : ratio >= warnAt
+    ? "#eab308"
+    : "#22c55e"
+
+  const data = {
+    labels: ["", ""],
+    datasets: [
+      {
+        data: [filled, 1 - filled],
+        backgroundColor: [color, "#e5e7eb"],
+        borderWidth: 0,
+        circumference: 180,
+        rotation: 270,
+      },
+    ],
+  }
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    cutout: "72%",
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: false },
+    },
+  }
+
+  return (
+    <div className="flex w-full flex-col items-center">
+      <div className="relative h-24 w-full">
+        <Doughnut data={data} options={options} />
+        <div className="absolute inset-0 flex items-end justify-center pb-1">
+          <span className="text-xl font-bold text-slate-800">
+            {hasValue ? formatRatio(ratio) : "N/A"}
+          </span>
+        </div>
+      </div>
+      {label && <p className="mt-1 text-center text-xs text-slate-500">{label}</p>}
+    </div>
+  )
+}

--- a/src/hooks/useProjectRole.ts
+++ b/src/hooks/useProjectRole.ts
@@ -1,0 +1,92 @@
+"use client"
+
+/**
+ * Resuelve el rol del usuario actual dentro de un proyecto, combinando el rol
+ * global (useAuth) con la membresía del proyecto (getProjectMembers).
+ *
+ * El backend solo expone admin|user a nivel global; el rol de proyecto
+ * (project_manager, etc.) hay que derivarlo de la lista de miembros.
+ *
+ * Reglas del contrato de Finanzas (docs/finanzas-frontend.md):
+ * - monthly_rate visible para admin global o PM del proyecto.
+ * - gastos/facturas: gestionar = admin o PM; ver = cualquier miembro.
+ * - miembros: gestionar = solo admin.
+ */
+
+import { useEffect, useState } from "react"
+import { useAuth } from "@/hooks/useAuth"
+import { getProjectMembers, ProjectMemberRole } from "@/services/memberService"
+
+export interface ProjectRole {
+  isGlobalAdmin: boolean
+  isProjectManager: boolean
+  isMember: boolean
+  /** Puede ver montos sensibles (monthly_rate). */
+  canSeeRates: boolean
+  /** Puede crear/editar/borrar gastos y facturas. */
+  canManageFinance: boolean
+  /** Puede gestionar miembros del proyecto (solo admin global). */
+  canManageMembers: boolean
+  loading: boolean
+  error: string | null
+}
+
+export function useProjectRole(projectId: string | null | undefined): ProjectRole {
+  const { user, isLoading: authLoading } = useAuth()
+  const [role, setRole] = useState<ProjectMemberRole | null>(null)
+  const [isMember, setIsMember] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    const load = async () => {
+      if (!projectId || !user) {
+        // Sin proyecto resuelto o sin sesión aún: no hay rol de proyecto que cargar.
+        setRole(null)
+        setIsMember(false)
+        setLoading(false)
+        return
+      }
+
+      setLoading(true)
+      setError(null)
+
+      try {
+        const members = await getProjectMembers(projectId)
+        if (!active) return
+        const mine = members.find((member) => member.userId === user.id)
+        setIsMember(Boolean(mine))
+        setRole(mine?.role ?? null)
+      } catch (err) {
+        if (!active) return
+        setError(err instanceof Error ? err.message : "No se pudo resolver el rol del proyecto.")
+        setRole(null)
+        setIsMember(false)
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    load()
+
+    return () => {
+      active = false
+    }
+  }, [projectId, user, authLoading])
+
+  const isGlobalAdmin = user?.role === "admin"
+  const isProjectManager = role === "project_manager"
+
+  return {
+    isGlobalAdmin,
+    isProjectManager,
+    isMember: isMember || isGlobalAdmin,
+    canSeeRates: isGlobalAdmin || isProjectManager,
+    canManageFinance: isGlobalAdmin || isProjectManager,
+    canManageMembers: isGlobalAdmin,
+    loading: authLoading || loading,
+    error,
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,85 @@
+/**
+ * Helpers compartidos para consumir el backend con el envelope estándar
+ * `{ success, message, data }`. Extrae el patrón que ya usaban servicios
+ * como profileChangeRequestService para no duplicarlo en cada nuevo servicio.
+ */
+
+import { API_BASE_URL, getToken } from "@/lib/auth"
+
+export type ApiResponse<T> = {
+  success: boolean
+  message?: string
+  data?: T
+}
+
+/** Headers con Bearer token; lanza si no hay sesión activa. */
+export function authHeaders(): Record<string, string> {
+  const token = getToken()
+
+  if (!token) {
+    throw new Error("Sesión expirada. Inicia sesión nuevamente.")
+  }
+
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  }
+}
+
+/** Valida el envelope y devuelve `data`, o lanza con el mensaje del backend. */
+export async function parseEnvelope<T>(response: Response, fallbackMessage: string): Promise<T> {
+  const payload = (await response.json().catch(() => ({}))) as ApiResponse<T>
+
+  if (!response.ok || !payload.success || payload.data === undefined) {
+    throw new Error(payload.message || fallbackMessage)
+  }
+
+  return payload.data
+}
+
+export async function apiGet<T>(path: string, fallbackMessage: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "GET",
+    headers: authHeaders(),
+    cache: "no-store",
+  })
+
+  return parseEnvelope<T>(response, fallbackMessage)
+}
+
+async function apiSend<T>(
+  method: "POST" | "PATCH" | "PUT",
+  path: string,
+  body: unknown,
+  fallbackMessage: string
+): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers: authHeaders(),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+
+  return parseEnvelope<T>(response, fallbackMessage)
+}
+
+export function apiPost<T>(path: string, body: unknown, fallbackMessage: string): Promise<T> {
+  return apiSend<T>("POST", path, body, fallbackMessage)
+}
+
+export function apiPatch<T>(path: string, body: unknown, fallbackMessage: string): Promise<T> {
+  return apiSend<T>("PATCH", path, body, fallbackMessage)
+}
+
+/** DELETE que solo verifica `success` (no exige `data` en la respuesta). */
+export async function apiDelete(path: string, fallbackMessage: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "DELETE",
+    headers: authHeaders(),
+  })
+
+  const payload = (await response.json().catch(() => ({}))) as ApiResponse<unknown>
+
+  if (!response.ok || !payload.success) {
+    throw new Error(payload.message || fallbackMessage)
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,40 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Formatea un monto sin divisa fija (el backend no guarda divisa).
+ * Prefijo `$` + locale es-MX. Devuelve `fallback` ("N/A") si es null/NaN.
+ */
+export function formatMoney(value: number | null | undefined, fallback = "N/A"): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return fallback
+  }
+
+  return `$${value.toLocaleString("es-MX", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+/** Formatea un ratio 0..1 como porcentaje (0.42 -> "42%"). */
+export function formatRatio(value: number | null | undefined, fallback = "N/A"): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return fallback
+  }
+
+  return `${(value * 100).toLocaleString("es-MX", { maximumFractionDigits: 1 })}%`
+}
+
+/** Formatea un número plano con decimales acotados; null/NaN -> fallback. */
+export function formatNumber(
+  value: number | null | undefined,
+  fallback = "N/A",
+  maximumFractionDigits = 1
+): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return fallback
+  }
+
+  return value.toLocaleString("es-MX", { maximumFractionDigits })
+}

--- a/src/services/financeSummaryService.ts
+++ b/src/services/financeSummaryService.ts
@@ -1,0 +1,23 @@
+/**
+ * Servicio de analítica financiera de proyecto (solo lectura).
+ * Contrato: docs/finanzas-frontend.md secciones 1 (financial-summary) y 2 (evm).
+ */
+
+import { apiGet } from "@/lib/api"
+import { EvmData, FinancialSummary } from "@/types/finance"
+
+/** GET /projects/:id/financial-summary — KPIs base + serie de burn. */
+export function getFinancialSummary(projectId: string): Promise<FinancialSummary> {
+  return apiGet<FinancialSummary>(
+    `/projects/${projectId}/financial-summary`,
+    "No se pudo obtener el resumen financiero del proyecto."
+  )
+}
+
+/** GET /projects/:id/evm — Earned Value (PV/EV/AC, SPI/CPI, EAC...). */
+export function getProjectEvm(projectId: string): Promise<EvmData> {
+  return apiGet<EvmData>(
+    `/projects/${projectId}/evm`,
+    "No se pudo obtener el análisis EVM del proyecto."
+  )
+}

--- a/src/types/finance.ts
+++ b/src/types/finance.ts
@@ -1,0 +1,76 @@
+/**
+ * Tipos del módulo de Finanzas (contrato del backend BackPM).
+ * Ver docs/finanzas-frontend.md. Muchos campos derivados llegan `null`
+ * cuando faltan datos de entrada (sin presupuesto, sin fecha fin, etc.).
+ */
+
+export type BillingModel = "fixed_price" | "retainer" | "time_and_materials" | string
+
+/** Punto de la serie de burn acumulado. */
+export interface BurnPoint {
+  month: string // "YYYY-MM"
+  cumulativeEstimatedCost: number
+}
+
+/** GET /projects/:id/financial-summary */
+export interface FinancialSummary {
+  budget: number | null
+  monthlyCost: number | null
+  billingModel: BillingModel | null
+  /** 0..1+ — % de presupuesto consumido. */
+  budgetConsumedRatio: number | null
+  /** 0..1 — % de tiempo transcurrido. */
+  timeProgressRatio: number | null
+  estimatedSpend: number | null
+  remainingBudget: number | null
+  runwayMonths: number | null
+  budgetCoversPlannedEnd: boolean | null
+  projectedOverBudget: number | null
+  costPerStoryPoint: number | null
+  costPerEstimatedSprint: number | null
+  burnSeries: BurnPoint[]
+  /** Qué se pudo calcular; claves variables según el backend. */
+  dataAvailability: Record<string, boolean>
+  notes: string[]
+}
+
+/** Fuente del Actual Cost en EVM; indica la confiabilidad del CPI/EAC. */
+export type AcSource = "logged_hours" | "member_rates" | "project_monthly_cost"
+
+/** Punto de la curva-S de EVM. `ev`/`ac` son `null` en meses futuros. */
+export interface EvmSeriesPoint {
+  month: string // "YYYY-MM"
+  pv: number | null
+  ev: number | null
+  ac: number | null
+}
+
+export interface EvmDataAvailability {
+  hasBudget: boolean
+  hasSchedule: boolean
+  hasProgressMeasure: boolean
+  hasActualCost: boolean
+}
+
+/** GET /projects/:id/evm */
+export interface EvmData {
+  budget: number | null
+  statusDate: string | null
+  plannedValue: number | null
+  earnedValue: number | null
+  actualCost: number | null
+  scheduleVariance: number | null
+  costVariance: number | null
+  schedulePerformanceIndex: number | null
+  costPerformanceIndex: number | null
+  estimateAtCompletion: number | null
+  varianceAtCompletion: number | null
+  acSource: AcSource | null
+  laborCost: number | null
+  expensesTotal: number | null
+  loggedHours: number | null
+  acMonthlyCost: number | null
+  series: EvmSeriesPoint[]
+  dataAvailability: EvmDataAvailability
+  notes: string[]
+}


### PR DESCRIPTION
## Fase 1 del modulo de Finanzas (vista por proyecto, solo lectura)

Implementa los endpoints 1 (financial-summary), 2 (evm) y 3 (reporte PDF) del contrato `docs/finanzas-frontend.md`.

### Incluye
- **Capa compartida** reutilizable por fases siguientes: `src/types/finance.ts`, `src/lib/api.ts` (apiGet/Post/Patch/Delete + parseEnvelope), helpers `formatMoney/formatRatio/formatNumber`.
- **Hook** `useProjectRole` (deriva admin/PM del proyecto para permisos de fases futuras).
- **Servicio** `financeSummaryService` (financial-summary + evm).
- **Graficas** reutilizables: GaugeChart, BurnChart, EvmChart (chart.js).
- **Paneles** en `components/finance`: FinancialSummaryPanel, EvmPanel, ReportPanel (reusa el proxy de reporte existente).
- **Pagina** `projects/[projectId]/finance` con tabs Resumen/EVM/Reporte + enlaces desde tasks/progress + i18n.

### Verificacion
- ESLint acotado a archivos nuevos: 0 errores / 0 warnings.
- npm run build: compila y TypeScript pasa; ruta /projects/[projectId]/finance registrada.

Parte de una entrega por fases (Fase 2 portafolio, Fase 3 equipo/horas, Fase 4 gastos/facturas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)