### PR TITLE
PM-142: Finanzas Fase 3 - equipo (FTE/rate) y time tracking

### DIFF
--- a/src/app/(app)/projects/[projectId]/finance/page.tsx
+++ b/src/app/(app)/projects/[projectId]/finance/page.tsx
@@ -9,12 +9,16 @@ import { slugify } from "@/lib/slug"
 import FinancialSummaryPanel from "@/components/finance/FinancialSummaryPanel"
 import EvmPanel from "@/components/finance/EvmPanel"
 import ReportPanel from "@/components/finance/ReportPanel"
+import TeamRatesPanel from "@/components/finance/TeamRatesPanel"
+import TimeTrackingPanel from "@/components/finance/TimeTrackingPanel"
 
-type FinanceTab = "summary" | "evm" | "report"
+type FinanceTab = "summary" | "evm" | "team" | "hours" | "report"
 
 const TABS: { key: FinanceTab; label: string }[] = [
   { key: "summary", label: "Resumen" },
   { key: "evm", label: "EVM" },
+  { key: "team", label: "Equipo" },
+  { key: "hours", label: "Horas" },
   { key: "report", label: "Reporte" },
 ]
 
@@ -129,6 +133,8 @@ export default function ProjectFinancePage() {
 
       {tab === "summary" && <FinancialSummaryPanel projectId={projectId} />}
       {tab === "evm" && <EvmPanel projectId={projectId} />}
+      {tab === "team" && <TeamRatesPanel projectId={projectId} />}
+      {tab === "hours" && <TimeTrackingPanel projectId={projectId} />}
       {tab === "report" && <ReportPanel projectId={projectId} />}
     </div>
   )

--- a/src/components/finance/MemberRateModal.tsx
+++ b/src/components/finance/MemberRateModal.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import { useState } from "react"
+
+import { ProjectMemberFinance, ProjectMemberRole } from "@/types/finance"
+import { updateProjectFinanceMember } from "@/services/financeMembersService"
+
+const ROLE_OPTIONS: { value: ProjectMemberRole; label: string }[] = [
+  { value: "project_manager", label: "Project Manager" },
+  { value: "scrum_master", label: "Scrum Master" },
+  { value: "developer", label: "Developer" },
+  { value: "team_lead", label: "Team Lead" },
+]
+
+type MemberRateModalProps = {
+  projectId: string
+  member: ProjectMemberFinance
+  memberName: string
+  onClose: () => void
+  onSaved: () => void
+}
+
+export default function MemberRateModal({
+  projectId,
+  member,
+  memberName,
+  onClose,
+  onSaved,
+}: MemberRateModalProps) {
+  const [role, setRole] = useState<ProjectMemberRole>(member.role)
+  const [fte, setFte] = useState(member.fte !== null && member.fte !== undefined ? String(member.fte) : "")
+  const [rate, setRate] = useState(
+    member.monthly_rate !== null && member.monthly_rate !== undefined ? String(member.monthly_rate) : ""
+  )
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setSaving(true)
+    setError(null)
+
+    try {
+      await updateProjectFinanceMember(projectId, member.id_user, {
+        role,
+        fte: fte.trim() === "" ? null : Number(fte),
+        monthly_rate: rate.trim() === "" ? null : Number(rate),
+      })
+      onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo actualizar el miembro.")
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+        <h3 className="text-lg font-semibold text-slate-800">Editar miembro</h3>
+        <p className="mb-4 text-sm text-slate-500">{memberName}</p>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <label className="flex flex-col text-sm text-slate-700">
+            <span className="mb-1 font-medium">Rol</span>
+            <select
+              value={role}
+              onChange={(event) => setRole(event.target.value as ProjectMemberRole)}
+              className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+            >
+              {ROLE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col text-sm text-slate-700">
+            <span className="mb-1 font-medium">FTE (0–1)</span>
+            <input
+              type="number"
+              step="0.1"
+              min="0"
+              max="1"
+              value={fte}
+              onChange={(event) => setFte(event.target.value)}
+              placeholder="Ej: 0.5"
+              className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+            />
+          </label>
+
+          <label className="flex flex-col text-sm text-slate-700">
+            <span className="mb-1 font-medium">Tarifa mensual</span>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              value={rate}
+              onChange={(event) => setRate(event.target.value)}
+              placeholder="Sin tarifa"
+              className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+            />
+          </label>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saving}
+              className="rounded-2xl border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:shadow-sm disabled:opacity-60"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+            >
+              {saving ? "Guardando..." : "Guardar"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/finance/TeamRatesPanel.tsx
+++ b/src/components/finance/TeamRatesPanel.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { Pencil } from "lucide-react"
+
+import { ProjectMemberFinance } from "@/types/finance"
+import { getProjectFinanceMembers } from "@/services/financeMembersService"
+import { getProjectMembers } from "@/services/userService"
+import { useProjectRole } from "@/hooks/useProjectRole"
+import { formatMoney, formatNumber } from "@/lib/utils"
+import MemberRateModal from "@/components/finance/MemberRateModal"
+
+const ROLE_LABELS: Record<string, string> = {
+  project_manager: "Project Manager",
+  scrum_master: "Scrum Master",
+  developer: "Developer",
+  team_lead: "Team Lead",
+}
+
+export default function TeamRatesPanel({ projectId }: { projectId: string }) {
+  const { canSeeRates, canManageMembers } = useProjectRole(projectId)
+  const [members, setMembers] = useState<ProjectMemberFinance[]>([])
+  const [names, setNames] = useState<Record<string, string>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [editing, setEditing] = useState<ProjectMemberFinance | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const [financeMembers, users] = await Promise.all([
+        getProjectFinanceMembers(projectId),
+        getProjectMembers(projectId).catch(() => []),
+      ])
+
+      const nameMap: Record<string, string> = {}
+      users.forEach((user) => {
+        nameMap[user.id] = `${user.name ?? ""} ${user.lastname ?? ""}`.trim()
+      })
+
+      setMembers(financeMembers)
+      setNames(nameMap)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudieron cargar los miembros del proyecto.")
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const nameOf = (member: ProjectMemberFinance) => names[member.id_user] || member.id_user
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-slate-900" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+    )
+  }
+
+  const colSpan = 3 + (canSeeRates ? 1 : 0) + (canManageMembers ? 1 : 0)
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-xl border border-zinc-200 bg-white p-2 shadow-sm sm:p-4">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[560px] text-left text-sm">
+            <thead>
+              <tr className="border-b border-zinc-200 text-xs uppercase tracking-wide text-slate-500">
+                <th className="px-3 py-2">Miembro</th>
+                <th className="px-3 py-2">Rol</th>
+                <th className="px-3 py-2 text-right">FTE</th>
+                {canSeeRates && <th className="px-3 py-2 text-right">Tarifa mensual</th>}
+                {canManageMembers && <th className="px-3 py-2 text-center">Acciones</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {members.length === 0 ? (
+                <tr>
+                  <td colSpan={colSpan} className="px-3 py-8 text-center text-slate-400">
+                    Este proyecto no tiene miembros.
+                  </td>
+                </tr>
+              ) : (
+                members.map((member) => (
+                  <tr key={member.id_mp} className="border-b border-zinc-100 hover:bg-zinc-50">
+                    <td className="px-3 py-2 font-medium text-slate-800">{nameOf(member)}</td>
+                    <td className="px-3 py-2 text-slate-500">{ROLE_LABELS[member.role] ?? member.role}</td>
+                    <td className="px-3 py-2 text-right">{formatNumber(member.fte, "N/A", 2)}</td>
+                    {canSeeRates && (
+                      <td className="px-3 py-2 text-right">{formatMoney(member.monthly_rate)}</td>
+                    )}
+                    {canManageMembers && (
+                      <td className="px-3 py-2 text-center">
+                        <button
+                          type="button"
+                          onClick={() => setEditing(member)}
+                          aria-label="Editar miembro"
+                          className="rounded-md border border-transparent p-1.5 text-slate-400 transition hover:border-slate-200 hover:bg-slate-50 hover:text-slate-700"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {!canSeeRates && (
+        <p className="text-xs text-slate-400">
+          La tarifa mensual solo es visible para administradores o el PM del proyecto.
+        </p>
+      )}
+
+      {editing && (
+        <MemberRateModal
+          projectId={projectId}
+          member={editing}
+          memberName={nameOf(editing)}
+          onClose={() => setEditing(null)}
+          onSaved={() => {
+            setEditing(null)
+            load()
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/finance/TimeTrackingPanel.tsx
+++ b/src/components/finance/TimeTrackingPanel.tsx
@@ -1,0 +1,237 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { ProjectTimeSummary } from "@/types/finance"
+import { Task } from "@/types/task"
+import { createTimeEntry, getProjectTimeSummary } from "@/services/timeEntryService"
+import { getProjectMembers } from "@/services/userService"
+import { getProjectTasks } from "@/services/taskService"
+import { getToken } from "@/lib/auth"
+import { formatNumber } from "@/lib/utils"
+import HoursBarChart from "@/components/ui/graphs/HoursBarChart"
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-1 text-2xl font-bold text-slate-800">{value}</p>
+    </div>
+  )
+}
+
+export default function TimeTrackingPanel({ projectId }: { projectId: string }) {
+  const [summary, setSummary] = useState<ProjectTimeSummary | null>(null)
+  const [names, setNames] = useState<Record<string, string>>({})
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [taskId, setTaskId] = useState("")
+  const [hours, setHours] = useState("")
+  const [workDate, setWorkDate] = useState("")
+  const [description, setDescription] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitOk, setSubmitOk] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const token = getToken() || ""
+      const [timeSummary, users, taskList] = await Promise.all([
+        getProjectTimeSummary(projectId),
+        getProjectMembers(projectId).catch(() => []),
+        getProjectTasks(projectId, token).catch(() => [] as Task[]),
+      ])
+
+      const nameMap: Record<string, string> = {}
+      users.forEach((user) => {
+        nameMap[user.id] = `${user.name ?? ""} ${user.lastname ?? ""}`.trim()
+      })
+
+      setSummary(timeSummary)
+      setNames(nameMap)
+      setTasks(taskList)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "No se pudo cargar el resumen de horas.")
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const taskTitle = (id: string) => tasks.find((task) => task.id === id)?.title || id
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setSubmitOk(false)
+
+    if (!taskId) {
+      setSubmitError("Selecciona una tarea.")
+      return
+    }
+
+    const parsedHours = Number(hours)
+    if (!hours || Number.isNaN(parsedHours) || parsedHours <= 0 || parsedHours > 24) {
+      setSubmitError("Las horas deben estar entre 0 y 24.")
+      return
+    }
+
+    if (!workDate) {
+      setSubmitError("Selecciona la fecha.")
+      return
+    }
+
+    setSubmitting(true)
+    setSubmitError(null)
+
+    try {
+      await createTimeEntry(taskId, {
+        hours: parsedHours,
+        work_date: workDate,
+        description: description.trim() || undefined,
+      })
+
+      setHours("")
+      setDescription("")
+      setSubmitOk(true)
+      await load()
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "No se pudieron registrar las horas.")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-zinc-300 border-t-slate-900" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+    )
+  }
+
+  if (!summary) return null
+
+  return (
+    <div className="space-y-6">
+      {/* KPIs */}
+      <section className="grid grid-cols-2 gap-4">
+        <StatCard label="Horas totales" value={formatNumber(summary.totalHours)} />
+        <StatCard label="Registros" value={formatNumber(summary.entryCount, "0", 0)} />
+      </section>
+
+      {/* Gráficas */}
+      <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm">
+          <h3 className="mb-3 text-sm font-semibold text-slate-800">Horas por usuario</h3>
+          <div className="h-64">
+            <HoursBarChart
+              labels={summary.byUser.map((bucket) => names[bucket.id] || bucket.id)}
+              values={summary.byUser.map((bucket) => bucket.hours)}
+              color="#6366f1"
+            />
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm">
+          <h3 className="mb-3 text-sm font-semibold text-slate-800">Horas por tarea</h3>
+          <div className="h-64">
+            <HoursBarChart
+              labels={summary.byTask.map((bucket) => taskTitle(bucket.id))}
+              values={summary.byTask.map((bucket) => bucket.hours)}
+              color="#10b981"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Alta de horas */}
+      <section className="rounded-xl border border-zinc-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-slate-800">Registrar horas</h3>
+        <p className="mb-4 text-xs text-slate-500">Registra tus horas trabajadas en una tarea del proyecto.</p>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <label className="flex flex-col text-sm text-slate-700 md:col-span-2">
+              <span className="mb-1 font-medium">Tarea</span>
+              <select
+                value={taskId}
+                onChange={(event) => setTaskId(event.target.value)}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              >
+                <option value="">Selecciona una tarea</option>
+                {tasks.map((task) => (
+                  <option key={task.id} value={task.id}>
+                    {task.title}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col text-sm text-slate-700">
+              <span className="mb-1 font-medium">Horas (0–24)</span>
+              <input
+                type="number"
+                step="0.25"
+                min="0"
+                max="24"
+                value={hours}
+                onChange={(event) => setHours(event.target.value)}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <label className="flex flex-col text-sm text-slate-700">
+              <span className="mb-1 font-medium">Fecha</span>
+              <input
+                type="date"
+                value={workDate}
+                onChange={(event) => setWorkDate(event.target.value)}
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+
+            <label className="flex flex-col text-sm text-slate-700 md:col-span-2">
+              <span className="mb-1 font-medium">Descripción (opcional)</span>
+              <input
+                type="text"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="Ej: Implementación del endpoint de login"
+                className="rounded-md border border-zinc-300 px-3 py-2 text-sm focus:border-slate-400 focus:outline-none"
+              />
+            </label>
+          </div>
+
+          {submitError && <p className="text-sm text-red-600">{submitError}</p>}
+          {submitOk && <p className="text-sm text-emerald-600">Horas registradas correctamente.</p>}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-2xl bg-slate-900 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+            >
+              {submitting ? "Guardando..." : "Registrar"}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  )
+}

--- a/src/components/i18n/LanguageProvider.tsx
+++ b/src/components/i18n/LanguageProvider.tsx
@@ -297,6 +297,32 @@ const esToEnEntries: Array<[string, string]> = [
   ["En pausa", "On hold"],
   ["No hay proyectos en tu portafolio.", "There are no projects in your portfolio."],
 
+  // Finanzas Fase 3 — equipo y horas (PM-142)
+  ["Equipo", "Team"],
+  ["Horas", "Hours"],
+  ["Miembro", "Member"],
+  ["Tarifa mensual", "Monthly rate"],
+  ["La tarifa mensual solo es visible para administradores o el PM del proyecto.", "The monthly rate is only visible to administrators or the project PM."],
+  ["Este proyecto no tiene miembros.", "This project has no members."],
+  ["Editar miembro", "Edit member"],
+  ["Guardar", "Save"],
+  ["Guardando...", "Saving..."],
+  ["Sin tarifa", "No rate"],
+  ["No se pudieron cargar los miembros del proyecto.", "The project members could not be loaded."],
+  ["Horas totales", "Total hours"],
+  ["Horas por usuario", "Hours by user"],
+  ["Horas por tarea", "Hours by task"],
+  ["Sin horas registradas.", "No hours logged."],
+  ["Registrar horas", "Log hours"],
+  ["Registra tus horas trabajadas en una tarea del proyecto.", "Log your hours worked on a project task."],
+  ["Selecciona una tarea.", "Select a task."],
+  ["Selecciona una tarea", "Select a task"],
+  ["Las horas deben estar entre 0 y 24.", "Hours must be between 0 and 24."],
+  ["Selecciona la fecha.", "Select the date."],
+  ["Descripción (opcional)", "Description (optional)"],
+  ["Horas registradas correctamente.", "Hours logged successfully."],
+  ["Registrar", "Log"],
+
 ];
 
 const enToEsEntries: Array<[string, string]> = esToEnEntries.map(([es, en]) => [en, es]);

--- a/src/components/ui/graphs/HoursBarChart.tsx
+++ b/src/components/ui/graphs/HoursBarChart.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip } from "chart.js"
+import { Bar } from "react-chartjs-2"
+import { formatNumber } from "@/lib/utils"
+
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip)
+
+type HoursBarChartProps = {
+  labels: string[]
+  values: number[]
+  color?: string
+}
+
+export default function HoursBarChart({ labels, values, color = "#6366f1" }: HoursBarChartProps) {
+  if (labels.length === 0) {
+    return <p className="py-8 text-center text-sm text-slate-400">Sin horas registradas.</p>
+  }
+
+  const data = {
+    labels,
+    datasets: [
+      {
+        label: "Horas",
+        data: values,
+        backgroundColor: color,
+        borderRadius: 6,
+        barThickness: 16,
+      },
+    ],
+  }
+
+  const options = {
+    indexAxis: "y" as const,
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (context: { raw: unknown }) => `${formatNumber(Number(context.raw))} h`,
+        },
+      },
+    },
+    scales: {
+      x: { beginAtZero: true, grid: { color: "rgba(0,0,0,0.05)" }, ticks: { font: { size: 11 } } },
+      y: { grid: { display: false }, ticks: { font: { size: 11 } } },
+    },
+  }
+
+  return (
+    <div className="h-full w-full">
+      <Bar data={data} options={options} />
+    </div>
+  )
+}

--- a/src/services/financeMembersService.ts
+++ b/src/services/financeMembersService.ts
@@ -1,0 +1,52 @@
+/**
+ * Miembros de proyecto con datos financieros (FTE / monthly_rate).
+ * Contrato: docs/finanzas-frontend.md sección 4.
+ *
+ * El endpoint /projects/:id/members es compartido con el resto de la app y
+ * puede responder un array crudo o el envelope {success,data}; por eso el GET
+ * es tolerante a ambas formas (igual que userService/memberService).
+ */
+
+import { API_BASE_URL } from "@/lib/auth"
+import { authHeaders } from "@/lib/api"
+import { ProjectMemberFinance, ProjectMemberRole } from "@/types/finance"
+
+export interface UpdateMemberPayload {
+  role?: ProjectMemberRole
+  fte?: number | null
+  monthly_rate?: number | null
+}
+
+/** GET /projects/:id/members — incluye fte y monthly_rate (rate = null si no autorizado). */
+export async function getProjectFinanceMembers(projectId: string): Promise<ProjectMemberFinance[]> {
+  const response = await fetch(`${API_BASE_URL}/projects/${projectId}/members`, {
+    method: "GET",
+    headers: authHeaders(),
+    cache: "no-store",
+  })
+
+  if (!response.ok) {
+    throw new Error("No se pudieron obtener los miembros del proyecto.")
+  }
+
+  const data = await response.json()
+  return Array.isArray(data) ? data : data.data || []
+}
+
+/** PATCH /projects/:id/members/:userId — rol/fte/rate (solo admin). La UI refetchea tras éxito. */
+export async function updateProjectFinanceMember(
+  projectId: string,
+  userId: string,
+  payload: UpdateMemberPayload
+): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/projects/${projectId}/members/${userId}`, {
+    method: "PATCH",
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  })
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}))
+    throw new Error(error.message || "No se pudo actualizar el miembro.")
+  }
+}

--- a/src/services/timeEntryService.ts
+++ b/src/services/timeEntryService.ts
@@ -1,0 +1,52 @@
+/**
+ * Time tracking: registro de horas por tarea y resumen por proyecto.
+ * Contrato: docs/finanzas-frontend.md sección 5.
+ */
+
+import { apiDelete, apiGet, apiPatch, apiPost } from "@/lib/api"
+import { ProjectTimeSummary, TimeEntry } from "@/types/finance"
+
+export interface TimeEntryPayload {
+  hours: number
+  work_date: string
+  description?: string
+}
+
+/** GET /projects/:id/time-summary — totales + agregados byUser/byTask. */
+export function getProjectTimeSummary(projectId: string): Promise<ProjectTimeSummary> {
+  return apiGet<ProjectTimeSummary>(
+    `/projects/${projectId}/time-summary`,
+    "No se pudo obtener el resumen de horas."
+  )
+}
+
+/** GET /tasks/:taskId/time-entries — registros de una tarea. */
+export function getTaskTimeEntries(taskId: string): Promise<TimeEntry[]> {
+  return apiGet<TimeEntry[]>(
+    `/tasks/${taskId}/time-entries`,
+    "No se pudieron obtener los registros de horas."
+  )
+}
+
+/** POST /tasks/:taskId/time-entries — registra horas (cada quien las suyas; admin cualquiera). */
+export function createTimeEntry(taskId: string, payload: TimeEntryPayload): Promise<TimeEntry> {
+  return apiPost<TimeEntry>(
+    `/tasks/${taskId}/time-entries`,
+    payload,
+    "No se pudieron registrar las horas."
+  )
+}
+
+/** PATCH /time-entries/:id */
+export function updateTimeEntry(entryId: string, payload: Partial<TimeEntryPayload>): Promise<TimeEntry> {
+  return apiPatch<TimeEntry>(
+    `/time-entries/${entryId}`,
+    payload,
+    "No se pudo actualizar el registro de horas."
+  )
+}
+
+/** DELETE /time-entries/:id */
+export function deleteTimeEntry(entryId: string): Promise<void> {
+  return apiDelete(`/time-entries/${entryId}`, "No se pudo eliminar el registro de horas.")
+}

--- a/src/types/finance.ts
+++ b/src/types/finance.ts
@@ -107,3 +107,44 @@ export interface FinancialPortfolio {
   summary: PortfolioSummary
   projects: PortfolioProject[]
 }
+
+/** Rol dentro de un proyecto (incluye team_lead). */
+export type ProjectMemberRole = "project_manager" | "scrum_master" | "developer" | "team_lead"
+
+/** Miembro de proyecto con datos financieros. `monthly_rate` llega null si no autorizado a verlo. */
+export interface ProjectMemberFinance {
+  id_mp: string
+  id_user: string
+  id_project: string
+  role: ProjectMemberRole
+  fte: number | null
+  monthly_rate: number | null
+  createdAt: string
+}
+
+/** Registro de horas en una tarea. */
+export interface TimeEntry {
+  id_time_entry: string
+  id_task: string
+  id_user: string
+  id_project: string
+  hours: number
+  work_date: string
+  description: string | null
+  createdAt: string
+}
+
+/** Bucket de horas agregadas (por usuario o por tarea); `id` es el id de usuario/tarea. */
+export interface TimeSummaryBucket {
+  id: string
+  hours: number
+  entries: number
+}
+
+/** GET /projects/:id/time-summary */
+export interface ProjectTimeSummary {
+  totalHours: number
+  entryCount: number
+  byUser: TimeSummaryBucket[]
+  byTask: TimeSummaryBucket[]
+}


### PR DESCRIPTION
## Fase 3 del modulo de Finanzas - Equipo + Time tracking

Implementa los endpoints 4 (members con FTE/rate) y 5 (time tracking) del contrato `docs/finanzas-frontend.md`.

### Incluye
- **Servicios**: `financeMembersService` (GET miembros tolerante a array/envelope + PATCH fte/rate/rol, admin) y `timeEntryService` (time-summary + CRUD de horas) con tipos en `types/finance`.
- **HoursBarChart** (grafica reutilizable).
- **TeamRatesPanel**: tabla de miembros (nombres via userService) con rol/FTE/tarifa; la columna de tarifa se oculta a quien no sea admin/PM (`useProjectRole.canSeeRates`) y muestra N/A si el rate es null; edicion de FTE/rate/rol solo admin via `MemberRateModal`.
- **TimeTrackingPanel**: KPIs (horas totales, registros), barras por usuario y por tarea (mapeando ids a nombres/titulos) y formulario de alta de horas por tarea.
- Pestanas **Equipo** y **Horas** en `projects/[projectId]/finance` e i18n es/en.

### Verificacion
- ESLint acotado a archivos nuevos: 0 errores / 0 warnings.
- npm run build: compila y TypeScript pasa.

Sigue a las Fases 1 (#71) y 2 (#72). Pendiente: Fase 4 (gastos + facturas) para cerrar el modulo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)