### PR TITLE
PM-148: Fix Finanzas - fecha con un dia menos e i18n Reporte/Concepto

### DIFF
--- a/src/components/finance/ExpensesPanel.tsx
+++ b/src/components/finance/ExpensesPanel.tsx
@@ -6,7 +6,7 @@ import { Pencil, Plus, Trash2 } from "lucide-react"
 import { Expense, ExpenseCategory } from "@/types/finance"
 import { deleteExpense, getProjectExpenses } from "@/services/expenseService"
 import { useProjectRole } from "@/hooks/useProjectRole"
-import { formatMoney } from "@/lib/utils"
+import { formatDate, formatMoney } from "@/lib/utils"
 import CategoryDonut from "@/components/ui/graphs/CategoryDonut"
 import ExpenseFormModal from "@/components/finance/ExpenseFormModal"
 
@@ -16,12 +16,6 @@ const CATEGORY_LABELS: Record<ExpenseCategory, string> = {
   services: "Servicios",
   travel: "Viajes",
   other: "Otros",
-}
-
-function formatDate(iso: string): string {
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return iso
-  return date.toLocaleDateString("es-MX", { day: "2-digit", month: "short", year: "numeric" })
 }
 
 export default function ExpensesPanel({ projectId }: { projectId: string }) {

--- a/src/components/finance/InvoicesPanel.tsx
+++ b/src/components/finance/InvoicesPanel.tsx
@@ -6,7 +6,7 @@ import { Pencil, Plus, Trash2 } from "lucide-react"
 import { Invoice, InvoiceStatus, InvoiceSummary } from "@/types/finance"
 import { deleteInvoice, getProjectInvoices } from "@/services/invoiceService"
 import { useProjectRole } from "@/hooks/useProjectRole"
-import { formatMoney } from "@/lib/utils"
+import { formatDate, formatMoney } from "@/lib/utils"
 import GaugeChart from "@/components/ui/graphs/GaugeChart"
 import InvoiceFormModal from "@/components/finance/InvoiceFormModal"
 
@@ -29,12 +29,6 @@ function StatCard({ label, value }: { label: string; value: string }) {
       <p className="mt-1 text-xl font-bold text-slate-800">{value}</p>
     </div>
   )
-}
-
-function formatDate(iso: string): string {
-  const date = new Date(iso)
-  if (Number.isNaN(date.getTime())) return iso
-  return date.toLocaleDateString("es-MX", { day: "2-digit", month: "short", year: "numeric" })
 }
 
 export default function InvoicesPanel({ projectId }: { projectId: string }) {

--- a/src/components/i18n/LanguageProvider.tsx
+++ b/src/components/i18n/LanguageProvider.tsx
@@ -254,6 +254,7 @@ const esToEnEntries: Array<[string, string]> = [
   // Módulo de Finanzas (PM-139)
   ["Finanzas", "Finance"],
   ["Resumen", "Summary"],
+  ["Reporte", "Report"],
   ["KPIs financieros, EVM y reporte del proyecto.", "Financial KPIs, EVM and project report."],
   ["Burn acumulado", "Cumulative burn"],
   ["Costo estimado acumulado", "Cumulative estimated cost"],
@@ -354,6 +355,7 @@ const esToEnEntries: Array<[string, string]> = [
   ["No hay facturas registradas.", "No invoices recorded."],
   ["¿Eliminar esta factura?", "Delete this invoice?"],
   ["Concepto (opcional)", "Concept (optional)"],
+  ["Concepto", "Concept"],
   ["Emisión", "Issued"],
   ["Fecha de emisión", "Issue date"],
   ["Selecciona la fecha de emisión.", "Select the issue date."],
@@ -363,7 +365,12 @@ const esToEnEntries: Array<[string, string]> = [
 
 ];
 
-const enToEsEntries: Array<[string, string]> = esToEnEntries.map(([es, en]) => [en, es]);
+// No revertir pares donde el inglés es substring del español (Report⊂Reporte, Concept⊂Concepto):
+// al aplicar en->es sobre el texto fuente en español, el reemplazo por substring duplicaría la
+// cola ("Reportee"/"Conceptoo"). El sentido es->en (inglés es el default) sí los traduce.
+const enToEsEntries: Array<[string, string]> = esToEnEntries
+  .filter(([es, en]) => !es.includes(en))
+  .map(([es, en]) => [en, es]);
 
 const LanguageContext = createContext<LanguageContextValue | null>(null);
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,3 +41,19 @@ export function formatNumber(
 
   return value.toLocaleString("es-MX", { maximumFractionDigits })
 }
+
+/**
+ * Formatea una fecha sin corrimiento por zona horaria: toma solo la parte YYYY-MM-DD
+ * y la interpreta como fecha LOCAL. Evita que una fecha guardada como UTC-midnight se
+ * muestre un día antes en zonas con offset negativo (p. ej. UTC-6).
+ */
+export function formatDate(value: string | null | undefined, fallback = "—"): string {
+  if (!value) return fallback
+
+  const [year, month, day] = value.slice(0, 10).split("-").map(Number)
+  const date = year && month && day ? new Date(year, month - 1, day) : new Date(value)
+
+  if (Number.isNaN(date.getTime())) return fallback
+
+  return date.toLocaleDateString("es-MX", { day: "2-digit", month: "short", year: "numeric" })
+}


### PR DESCRIPTION
## Fixes (hallados en pruebas manuales contra el backend real)

### 1. Fecha con un dia menos
`formatDate` usaba `new Date(iso)` sobre la fecha UTC-midnight del backend y la convertia a hora local → se mostraba el dia anterior en zonas con offset negativo (p.ej. crear 2026-05-01 mostraba "30 abr"). Se movio `formatDate` a `src/lib/utils.ts` parseando `YYYY-MM-DD` como **fecha local**, y se usa en `ExpensesPanel` e `InvoicesPanel`.

### 2. i18n "Reportee" / "Conceptoo"
El fix anterior (quitar los pares) dejaba "Reporte"/"Concepto" sin traducir en ingles (el default). Ahora se re-agregan `["Reporte","Report"]` y `["Concepto","Concept"]`, y al generar el diccionario inverso (en->es) se **excluyen** los pares donde el ingles es substring del espanol. Asi traduce bien en ingles y no mancha en espanol (el matcher por substring no toca el resto).

### Verificacion (runtime + build)
- Crear gasto 2026-05-15 → muestra "15 may 2026".
- EN: pestana "Report" / columna "CONCEPT". ES: "Reporte" / "CONCEPTO" (sin doble letra).
- ESLint acotado 0 problemas; `npm run build` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)