### PR TITLE
PM-156: Perfil robusto - skill/area, sesion compartida y carga confiable

### DIFF
--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -253,11 +253,14 @@ export default function ProfileDashboard() {
     };
   }, [user?.id]);
 
+  // skill/área/foto salen del perfil cargado por página si está; si ese fetch
+  // parpadea/se cancela con la red inestable, caen a la sesión enriquecida
+  // (estable, obtenida una vez por el AuthProvider). Así siempre se muestran.
   const displayName = profile ? `${profile.name} ${profile.lastname}`.trim() : `${user?.name ?? ""} ${user?.lastname ?? ""}`.trim();
   const email = profile?.email ?? user?.email ?? "Sin correo disponible";
-  const avatarSrc = profile?.profileImageUrl ?? user?.avatar ?? "/images/persona.png";
-  const mainSkill = profile?.skill?.trim() || "No definida";
-  const areaList = splitValues(profile?.area);
+  const avatarSrc = profile?.profileImageUrl ?? user?.profileImageUrl ?? user?.avatar ?? "/images/persona.png";
+  const mainSkill = (profile?.skill ?? user?.skill)?.trim() || "No definida";
+  const areaList = splitValues(profile?.area ?? user?.area);
   const technologyNames = technologies.map((item) => item.technology.trim()).filter(Boolean);
   const isAdmin = user?.role === "admin"
 

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -152,8 +152,6 @@ export default function ProfileDashboard() {
   const { user } = useAuth()
 
   const [profile, setProfile] = useState<UserProfileDetails | null>(null);
-  const [profileLoading, setProfileLoading] = useState(true);
-  const [profileError, setProfileError] = useState<string | null>(null);
   const [technologies, setTechnologies] = useState<UserTechnologyEntry[]>([]);
   const [myTasks, setMyTasks] = useState<Task[]>([])
   const [tasksLoading, setTasksLoading] = useState(true)
@@ -227,15 +225,9 @@ export default function ProfileDashboard() {
     let cancelled = false;
 
     async function loadProfile() {
-      if (!user?.id) {
-        setProfile(null);
-        setTechnologies([]);
-        setProfileLoading(false);
-        return;
-      }
-
-      setProfileLoading(true);
-      setProfileError(null);
+      // Sin id aún (sesión cargando) no pedimos nada, pero NO borramos lo ya
+      // cargado: si la sesión parpadea con red inestable, no perdemos los datos.
+      if (!user?.id) return;
 
       try {
         const [profileData, technologiesData] = await Promise.all([
@@ -249,13 +241,7 @@ export default function ProfileDashboard() {
         }
       } catch (err) {
         if (!cancelled) {
-          setProfileError(err instanceof Error ? err.message : "No se pudo cargar el perfil");
-          setProfile(null);
-          setTechnologies([]);
-        }
-      } finally {
-        if (!cancelled) {
-          setProfileLoading(false);
+          console.error("No se pudo cargar el perfil:", err);
         }
       }
     }
@@ -401,10 +387,10 @@ export default function ProfileDashboard() {
 
               <div className="space-y-1">
                 <h2 className="font-semibold text-base sm:text-lg">
-                  {profileLoading ? "Cargando perfil..." : displayName || "Usuario"}
+                  {displayName || "Usuario"}
                 </h2>
                 <p className="text-xs sm:text-sm text-gray-500">
-                  {profileLoading ? "Obteniendo datos del usuario" : email}
+                  {email}
                 </p>
                 <div className="mt-3">
                   <ThemeToggle />
@@ -414,22 +400,16 @@ export default function ProfileDashboard() {
               <div className="grid w-full grid-cols-1 gap-3 pt-2 text-left sm:grid-cols-2">
                 <div className="rounded-xl border border-gray-100 bg-gray-50 px-3 py-3">
                   <p className="text-[11px] uppercase tracking-wide text-gray-400">Skill principal</p>
-                  <p className="mt-1 text-sm font-medium text-gray-800">{profileLoading ? "..." : mainSkill}</p>
+                  <p className="mt-1 text-sm font-medium text-gray-800">{mainSkill}</p>
                 </div>
 
                 <div className="rounded-xl border border-gray-100 bg-gray-50 px-3 py-3">
                   <p className="text-[11px] uppercase tracking-wide text-gray-400">Area</p>
                   <p className="mt-1 text-sm font-medium text-gray-800">
-                    {profileLoading ? "..." : areaList.length > 0 ? areaList.join(", ") : "No definida"}
+                    {areaList.length > 0 ? areaList.join(", ") : "No definida"}
                   </p>
                 </div>
               </div>
-
-              {profileError && (
-                <p className="w-full rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-left text-xs text-red-600">
-                  {profileError}
-                </p>
-              )}
             </div>
           </Card>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { LanguageProvider } from "@/components/i18n/LanguageProvider";
 import { NotificationProvider } from "@/components/ui/notifications/NotificationProvider";
 import ThemeProvider from "@/components/ui/ThemeProvider";
+import { AuthProvider } from "@/components/auth/AuthProvider";
 
 const figtree = Figtree({subsets:['latin'],variable:'--font-sans', preload: false});
 
@@ -33,11 +34,13 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className={cn("font-sans", figtree.variable)}>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ThemeProvider>
-          <LanguageProvider>
-            <NotificationProvider>{children}</NotificationProvider>
-          </LanguageProvider>
-        </ThemeProvider>
+        <AuthProvider>
+          <ThemeProvider>
+            <LanguageProvider>
+              <NotificationProvider>{children}</NotificationProvider>
+            </LanguageProvider>
+          </ThemeProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+/*
+Provee la sesión de autenticación a toda la app. Se monta UNA vez en el layout
+raíz, verifica la sesión (GET /auth/me, con reintentos en getCurrentUser) una
+sola vez, y expone el estado vía contexto. Las páginas leen con useAuth() sin
+volver a pedir /auth/me en cada navegación.
+*/
+
+import { useEffect, useState } from 'react'
+import { LoginResult, User, UserRole } from '@/types/auth'
+import {
+  getCurrentUser,
+  getDashboardRouteByRole,
+  getToken,
+  loginUser,
+  logout as logoutUser,
+} from '@/lib/auth'
+import { AuthContext, AuthContextValue } from '@/hooks/useAuth'
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Verifica la sesión una sola vez al montar (a nivel app, no por página).
+  useEffect(() => {
+    let cancelled = false
+
+    async function checkUser() {
+      try {
+        const token = getToken()
+        if (!token) {
+          if (!cancelled) setIsLoading(false)
+          return
+        }
+
+        const currentUser = await getCurrentUser()
+        if (!cancelled && currentUser) {
+          setUser(currentUser)
+          setIsAuthenticated(true)
+        }
+      } catch (err) {
+        console.error('Error verificando usuario:', err)
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    checkUser()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function login(email: string, password: string): Promise<LoginResult> {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const response = await loginUser(email, password)
+
+      if (response.success && response.data?.token) {
+        const currentUser = await getCurrentUser()
+
+        if (!currentUser) {
+          setError('No se pudo obtener la sesión del usuario')
+          return { success: false }
+        }
+
+        setUser(currentUser)
+        setIsAuthenticated(true)
+        return {
+          success: true,
+          redirectTo: getDashboardRouteByRole(currentUser.role),
+        }
+      }
+
+      setError(response.message || 'Error al iniciar sesión')
+      return { success: false }
+    } catch (err) {
+      setError('Error al iniciar sesión')
+      console.error(err)
+      return { success: false }
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  function logout() {
+    logoutUser()
+    setUser(null)
+    setIsAuthenticated(false)
+  }
+
+  function hasRole(requiredRole: UserRole): boolean {
+    return user?.role === requiredRole
+  }
+
+  const value: AuthContextValue = {
+    user,
+    isLoading,
+    isAuthenticated,
+    error,
+    login,
+    logout,
+    hasRole,
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -17,6 +17,28 @@ import {
   logout as logoutUser,
 } from '@/lib/auth'
 import { AuthContext, AuthContextValue } from '@/hooks/useAuth'
+import { getUserProfileDetails } from '@/services/userService'
+
+/*
+skill/área/foto NO vienen en /auth/me. La única fuente del backend es GET /users
+(el front filtra por id). Lo hacemos UNA vez aquí —no por página— para que estos
+campos vivan en la sesión compartida y estable, en vez de en un fetch por página
+que se re-ejecuta/cancela con la red inestable. Si /users falla, conservamos la
+sesión básica (name/email/role) y skill/área quedan sin definir.
+*/
+async function enrichUserWithProfile(baseUser: User): Promise<User> {
+  try {
+    const details = await getUserProfileDetails(baseUser.id)
+    return {
+      ...baseUser,
+      skill: details.skill,
+      area: details.area,
+      profileImageUrl: details.profileImageUrl,
+    }
+  } catch {
+    return baseUser
+  }
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
@@ -38,8 +60,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         const currentUser = await getCurrentUser()
         if (!cancelled && currentUser) {
+          // Sesión básica primero (name/email/role) para no bloquear el ruteo.
           setUser(currentUser)
           setIsAuthenticated(true)
+          // Luego enriquecemos con skill/área/foto desde /users.
+          const enriched = await enrichUserWithProfile(currentUser)
+          if (!cancelled) setUser(enriched)
         }
       } catch (err) {
         console.error('Error verificando usuario:', err)
@@ -72,6 +98,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         setUser(currentUser)
         setIsAuthenticated(true)
+        // Enriquecer skill/área/foto en segundo plano: no bloquea el redirect.
+        enrichUserWithProfile(currentUser)
+          .then((enriched) => setUser(enriched))
+          .catch(() => {})
         return {
           success: true,
           redirectTo: getDashboardRouteByRole(currentUser.role),

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,119 +1,35 @@
 'use client'
 
-/* 
-Este hook centraliza toda la lógica de autenticación.
+/*
+Sesión compartida vía contexto.
 
-Permite a cualquier componente hacer: 
-
-const { user, login, logout } = useAuth()
-
-sin tener que repetir lógica.
-
+El estado de autenticación (usuario, login, logout) vive en <AuthProvider>
+(montado una sola vez en la raíz). useAuth() solo lo lee, así que la sesión se
+obtiene UNA vez y se comparte entre todas las páginas, en lugar de que cada
+componente vuelva a pedir /auth/me al montar.
 */
 
-import { useEffect, useState } from 'react'
+import { createContext, useContext } from 'react'
 import { LoginResult, User, UserRole } from '@/types/auth'
-import { getCurrentUser, getDashboardRouteByRole, loginUser, logout as logoutUser, getToken } from '@/lib/auth'
 
-export function useAuth() {
-  const [user, setUser] = useState<User | null>(null)
+export type AuthContextValue = {
+  user: User | null
+  isLoading: boolean
+  isAuthenticated: boolean
+  error: string | null
+  login: (email: string, password: string) => Promise<LoginResult>
+  logout: () => void
+  hasRole: (role: UserRole) => boolean
+}
 
-  const [isLoading, setIsLoading] = useState(true)
+export const AuthContext = createContext<AuthContextValue | null>(null)
 
-  const [isAuthenticated, setIsAuthenticated] = useState(false)
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext)
 
-  const [error, setError] = useState<string | null>(null)
-
-  // Verificar sesión al cargar app
-  // Este useEffect corre cuando el componente se monta.
-  // Solo verifica si hay un token guardado (sesión existente).
-  // Si no hay token, no intenta conectar con el servidor.
-  useEffect(() => {
-    async function checkUser() {
-      try {
-        const token = getToken()
-        
-        // Si no hay token, no intentes verificar sesión
-        if (!token) {
-          setIsLoading(false)
-          return
-        }
-
-        const currentUser = await getCurrentUser()
-
-        if (currentUser) {
-          setUser(currentUser)
-          setIsAuthenticated(true)
-        }
-      } catch (err) {
-        console.error('Error verificando usuario:', err)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-    checkUser()
-  }, [])
-
-  // Función Login
-  // Llama al servicio loginUser del backend.
-  async function login(email: string, password: string): Promise<LoginResult> {
-    try {
-      setIsLoading(true)
-      setError(null)
-
-      const response = await loginUser(email, password)
-
-      if (response.success && response.data?.token) {
-        const currentUser = await getCurrentUser()
-
-        if (!currentUser) {
-          setError('No se pudo obtener la sesión del usuario')
-          return { success: false }
-        }
-
-        setUser(currentUser)
-        setIsAuthenticated(true)
-        return {
-          success: true,
-          redirectTo: getDashboardRouteByRole(currentUser.role),
-        }
-      } else {
-        setError(response.message || 'Error al iniciar sesión')
-        return { success: false }
-      }
-    } catch (err) {
-      setError('Error al iniciar sesión')
-      console.error(err)
-      return { success: false }
-    } finally {
-      setIsLoading(false)
-    }
+  if (!context) {
+    throw new Error('useAuth debe usarse dentro de <AuthProvider>')
   }
 
-  // Función Logout
-  // Limpia el token y el estado del usuario
-  function logout() {
-    logoutUser()
-
-    setUser(null)
-    setIsAuthenticated(false)
-  }
-
-  // Función hasRole
-  // Verifica si el usuario tiene un rol específico
-  function hasRole(requiredRole: UserRole): boolean {
-    if (!user) return false
-
-    return user.role === requiredRole
-  }
-
-  return {
-    user,
-    isLoading,
-    isAuthenticated,
-    error,
-    login,
-    logout,
-    hasRole,
-  }
+  return context
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -118,7 +118,11 @@ export async function getCurrentUser(): Promise<User | null> {
     })
 
     if (!response.ok) {
-      localStorage.removeItem('authToken')
+      // Solo invalidar la sesión si el servidor rechaza el token (401).
+      // Un 5xx o un blip transitorio de red no debe borrar el token ni desloguear.
+      if (response.status === 401) {
+        localStorage.removeItem('authToken')
+      }
       return null
     }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -99,47 +99,63 @@ export function getToken(): string | null {
   return localStorage.getItem('authToken')
 }
 
-/* Función para obtener el usuario autenticado | GET /auth/me */
+/* Función para obtener el usuario autenticado | GET /auth/me
+ * Reintenta ante errores de red o 5xx (blips de Render) para que la sesión se
+ * obtenga de forma confiable en redes inestables. NO reintenta en 401 (token
+ * inválido) ni borra el token salvo en ese caso. */
 export async function getCurrentUser(): Promise<User | null> {
-  try {
-    const token = getToken()
+  const token = getToken()
 
-    if (!token) {
-      return null
-    }
-
-    const response = await fetch(`${API_BASE_URL}/auth/me`, {
-      method: 'GET',
-
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-    })
-
-    if (!response.ok) {
-      // Solo invalidar la sesión si el servidor rechaza el token (401).
-      // Un 5xx o un blip transitorio de red no debe borrar el token ni desloguear.
-      if (response.status === 401) {
-        localStorage.removeItem('authToken')
-      }
-      return null
-    }
-
-    const data: BackendMeResponse = await response.json()
-
-    if (!data.success || !data.data) {
-      return null
-    }
-
-    return {
-      ...data.data,
-      role: normalizeUserRole(data.data.role),
-    }
-  } catch (error) {
-    console.error('Error obtenido usuario:', error)
+  if (!token) {
     return null
   }
+
+  const maxAttempts = 3
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const response = await fetch(`${API_BASE_URL}/auth/me`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      })
+
+      if (response.status === 401) {
+        // Token rechazado por el servidor: invalidar sesión, sin reintentar.
+        localStorage.removeItem('authToken')
+        return null
+      }
+
+      if (!response.ok) {
+        // 5xx u otro: probablemente un blip; reintentar antes de rendirse.
+        if (attempt === maxAttempts) return null
+        await new Promise((resolve) => setTimeout(resolve, 600 * attempt))
+        continue
+      }
+
+      const data: BackendMeResponse = await response.json()
+
+      if (!data.success || !data.data) {
+        return null
+      }
+
+      return {
+        ...data.data,
+        role: normalizeUserRole(data.data.role),
+      }
+    } catch (error) {
+      // Error de red (Failed to fetch): reintentar; el token se conserva.
+      if (attempt === maxAttempts) {
+        console.error('Error obtenido usuario:', error)
+        return null
+      }
+      await new Promise((resolve) => setTimeout(resolve, 600 * attempt))
+    }
+  }
+
+  return null
 }
 
 /* Función para cerrar sesión */

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -94,6 +94,31 @@ function getMultipartAuthHeaders(): Record<string, string> {
   };
 }
 
+/**
+ * fetch con reintentos ante errores de red o 5xx (blips de Render). No reintenta
+ * en 4xx (no se recuperan). Hace la carga del perfil confiable en redes inestables.
+ */
+async function fetchWithRetry(url: string, init: RequestInit, maxAttempts = 3): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const response = await fetch(url, init);
+      if (response.status >= 500 && attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 600 * attempt));
+        continue;
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts) break;
+      await new Promise((resolve) => setTimeout(resolve, 600 * attempt));
+    }
+  }
+
+  throw lastError ?? new Error("No se pudo conectar con el servidor");
+}
+
 export async function getNonAdminUsers(): Promise<UserOption[]> {
   const response = await fetch(`${API_URL}/users`, {
     method: "GET",
@@ -114,7 +139,7 @@ export async function getNonAdminUsers(): Promise<UserOption[]> {
 }
 
 export async function getUsersDirectory(): Promise<UserDirectoryEntry[]> {
-  const response = await fetch(`${API_URL}/users`, {
+  const response = await fetchWithRetry(`${API_URL}/users`, {
     method: "GET",
     headers: getAuthHeaders(),
     cache: "no-store",
@@ -151,7 +176,7 @@ export async function getUserProfileDetails(userId: string): Promise<UserProfile
 }
 
 export async function getUserTechnologies(userId: string): Promise<UserTechnologyEntry[]> {
-  const response = await fetch(`${API_URL}/users/${userId}/technologies`, {
+  const response = await fetchWithRetry(`${API_URL}/users/${userId}/technologies`, {
     method: "GET",
     headers: getAuthHeaders(),
     cache: "no-store",

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -22,6 +22,11 @@ export interface User {
   lastname: string
   role: UserRole
   avatar?: string
+  // skill/área/foto NO vienen en /auth/me; el AuthProvider los enriquece desde
+  // /users (la única fuente del backend) una sola vez al iniciar la sesión.
+  skill?: string | null
+  area?: string | null
+  profileImageUrl?: string | null
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
## Qué resuelve

El perfil no mostraba la información del usuario (nombre/email y, sobre todo, **skill principal** y **área**) en redes inestables (Render free tier).

## Causa raíz

- `skill`/`area` **no vienen en `/auth/me`**; su única fuente en el backend es `GET /users` (el front filtra por id).
- La página de perfil pedía ese dato en un fetch **por página** que se re-ejecutaba/cancelaba con los blips de red, dejando `profile = null` → "No definida" pese a existir el dato.
- Cada página re-pedía `/auth/me` con su propio estado, perdiendo la sesión al navegar.

## Solución

- **Sesión compartida** (`AuthProvider` montado una vez en la raíz): `/auth/me` se obtiene una sola vez y se comparte vía contexto (`useAuth` solo lee).
- **Enriquecimiento estable**: tras `/auth/me`, el `AuthProvider` completa la sesión con `skill`/`area`/foto desde `/users` **una sola vez** (sin bloquear el ruteo; si `/users` falla, conserva la sesión básica).
- **Render con fallback**: el perfil deriva `skill`/`area`/avatar de `profile ?? user`, así que aunque el fetch por página parpadee, caen a la sesión enriquecida.
- **Reintentos** en `getCurrentUser`, `getUsersDirectory` y `getUserTechnologies` ante errores de red/5xx (no en 4xx).

## Verificación (app corriendo contra el backend real)

- admin@test.com → Skill **Admin**, Área **Admin**.
- user@test.com → Skill **React**, Área **Frontend**.
- Nombre, email, avatar y tecnologías renderizan correctamente.

## Nota de seguridad (backend, fuera de este PR)

`GET /users` expone a cualquier usuario autenticado los hashes bcrypt y `resetToken` de todos los usuarios. Conviene que el backend incluya `skill`/`area` en `/auth/me` y deje de filtrar datos sensibles en `/users`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)